### PR TITLE
Read Kubeconfig path from env on priority.

### DIFF
--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -48,7 +48,6 @@ func GetKubeClient(kubeconfig string) *kubernetes.Clientset {
 			kubeconfig = GetKubeConfigPath()
 		}
 	}
-
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load kubeconfig: %v\n", err)

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -33,26 +33,23 @@ func RemoveDuplicatesAndSort(slice []string) []string {
 	return uniqueSlice
 }
 
-func getDefaultKubeConfigPath() string {
+func GetKubeConfigPath() string {
 	home := homedir.HomeDir()
 	return filepath.Join(home, ".kube", "config")
 }
 
-func loadOrGetKubeConfigPath(kubeconfig string) string {
+// GetKubeClient selects kubeconfig path and returns kubeClient
+// kubeconfig path selection priority: 1) user supplied kubeconfig, 2) KUBECONFIG envvar, 3) default kubeconfig
+func GetKubeClient(kubeconfig string) *kubernetes.Clientset {
 	if kubeconfig == "" {
 		if configEnv := os.Getenv("KUBECONFIG"); configEnv != "" {
 			kubeconfig = configEnv
 		} else {
-			kubeconfig = getDefaultKubeConfigPath()
+			kubeconfig = GetKubeConfigPath()
 		}
 	}
-	return kubeconfig
-}
 
-func GetKubeClient(kubeconfig string) *kubernetes.Clientset {
-	kubeconfigPath := loadOrGetKubeConfigPath(kubeconfig)
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load kubeconfig: %v\n", err)
 		os.Exit(1)

--- a/pkg/kor/kor_test.go
+++ b/pkg/kor/kor_test.go
@@ -85,7 +85,7 @@ kind: Config
 	return fakeContent
 }
 
-func TestGetKubeClient_fromEnvVar(t *testing.T) {
+func TestGetKubeClientFromEnvVar(t *testing.T) {
 	configFile, err := os.CreateTemp("", "kubeconfig-")
 	if err != nil {
 		t.Error(err)
@@ -105,7 +105,7 @@ func TestGetKubeClient_fromEnvVar(t *testing.T) {
 	}
 }
 
-func TestGetKubeClient_fromInput(t *testing.T) {
+func TestGetKubeClientFromInput(t *testing.T) {
 	configFile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)

--- a/pkg/kor/kor_test.go
+++ b/pkg/kor/kor_test.go
@@ -1,7 +1,9 @@
 package kor
 
 import (
+	"os"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -58,5 +60,58 @@ func TestCalculateResourceDifference(t *testing.T) {
 		if item != expectedDifference[i] {
 			t.Errorf("Difference item at index %d should be %s, but got %s", i, expectedDifference[i], item)
 		}
+	}
+}
+
+func TestGetDefaultKubeConfigPath(t *testing.T) {
+	path := getDefaultKubeConfigPath()
+	if !strings.Contains(path, ".kube") || !strings.Contains(path, "config") {
+		t.Errorf("Expected to find '.kube' and 'config' keywords in path, but got %s", path)
+	}
+}
+
+func TestLoadOrGetKubeConfigPath_ShouldReadEnvvar(t *testing.T) {
+	originalKCEnv := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", originalKCEnv)
+
+	testKCPath := "test/kubeconfig.yaml"
+	os.Setenv("KUBECONFIG", testKCPath)
+	kcPath := loadOrGetKubeConfigPath("")
+
+	if kcPath != testKCPath {
+		t.Errorf("Expected kubeconfig path to be %s, but got %s", testKCPath, kcPath)
+	}
+}
+
+func TestLoadOrGetKubeConfigPath_ShouldGetDefaultPath(t *testing.T) {
+	originalKCEnv := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", originalKCEnv)
+
+	testKCPath := "test/kubeconfig.yaml"
+	os.Setenv("KUBECONFIG", "")
+	kcPath := loadOrGetKubeConfigPath("")
+
+	if kcPath == testKCPath {
+		t.Errorf("Expected kubeconfig path to be different than %s, but got %s", testKCPath, kcPath)
+	}
+
+	if !strings.Contains(kcPath, ".kube") || !strings.Contains(kcPath, "config") {
+		t.Errorf("Expected to find '.kube' and 'config' keywords in path, but got %s", kcPath)
+	}
+
+}
+
+func TestLoadOrGetKubeConfigPath_ShouldReturnSameStringIfNonEmpty(t *testing.T) {
+	originalKCEnv := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", originalKCEnv)
+
+	inputKCPath := "test/inputkc.yaml"
+
+	testKCPath := "test/kubeconfig.yaml"
+	os.Setenv("KUBECONFIG", testKCPath)
+	kcPath := loadOrGetKubeConfigPath(inputKCPath)
+
+	if kcPath != inputKCPath {
+		t.Errorf("Expected kubeconfig path to be %s, but got %s", testKCPath, kcPath)
 	}
 }


### PR DESCRIPTION
This PR aims to read Kubeconfig path from environment first and as fallback uses default location.
Methods having only local use are kept/made local.
The unite tests are added to cover newly added code.
fixes #45 

