### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+*.yml
+kor
+images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.20.2-alpine AS builder
+
+WORKDIR /build
+COPY . .
+ENV CGO_ENABLED 0
+RUN go build .
+
+FROM alpine:3.18
+
+COPY --from=builder /build/kor /kor
+ENTRYPOINT [ "/kor" ]
+CMD ["--help"]


### PR DESCRIPTION
This commit adds a Dockerfile and .dockerignore to for containerizing the kor CLI tool. #64 #69 

example for using the image: `docker run --rm -i -v "$KUBECONFIG:/root/.kube/config" kor-image:tag all -n namespace`
or instead: `docker run --rm -i -v "/path/to/kube/config:/root/.kube/config" kor-image:tag all -n namespace`

The image should be pushed to dockerhub and ghcr.io with every release using goreleaser.

I was also thinking about adding to the Dockerfile `ENV KUBECONFIG=/kubeconfig` making it a bit easier to use the volume: `docker run --rm -i -v "/path/to/kube/config:/kubeconfig" kor-image:tag` but for now users can just add `-e KUBECONFIG=/kubeconfig -v "/path/to/kube/config:/kubeconfig"`.

@yonahd let me know what you think.