### PR TITLE
Fix: Add helm condition to skip secret manifest creation when slack secrets are not provided

### DIFF
--- a/charts/kor/templates/secret.yaml
+++ b/charts/kor/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- if and .Values.cronJob.enabled }}
+{{- if ne .Values.cronJob.slackAuthToken "" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,7 +7,9 @@ metadata:
 type: Opaque
 data:
   slack-auth-token: {{ .Values.cronJob.slackAuthToken | b64enc | quote }}
+{{- end }}
 
+{{- if ne .Values.cronJob.slackWebhookUrl "" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -14,3 +18,5 @@ metadata:
 type: Opaque
 data:
   slack-webhook-url: {{ .Values.cronJob.slackWebhookUrl | b64enc | quote }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
fix #100 
@yonahd 