### PR TITLE
fix: Resolve panic error due to redefined flags in kor

### DIFF
--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -55,9 +55,6 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVar(&opts.Token, "slack-auth-token", "", "Slack auth token to send notifications to. --slack-auth-token requires --slack-channel to be set.")
 	rootCmd.PersistentFlags().BoolVar(&opts.DeleteFlag, "delete", false, "Delete unused resources")
 	rootCmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Do not prompt for confirmation when deleting resources. Be careful using this flag!")
-	rootCmd.PersistentFlags().StringVar(&opts.WebhookURL, "slack-webhook-url", "", "Slack webhook URL to send notifications to")
-	rootCmd.PersistentFlags().StringVar(&opts.Channel, "slack-channel", "", "Slack channel to send notifications to. --slack-channel requires --slack-auth-token to be set.")
-	rootCmd.PersistentFlags().StringVar(&opts.Token, "slack-auth-token", "", "Slack auth token to send notifications to. --slack-auth-token requires --slack-channel to be set.")
 	addFilterOptionsFlag(rootCmd, filterOptions)
 
 	if err := filterOptions.Validate(); err != nil {


### PR DESCRIPTION
Description:
The issue was causing a panic error when running kor due to redefined flags on root.cmd (lines 58-60). This commit addresses the problem by removing the duplicated flags.

Fixes: #124 