### PR TITLE
feat:add version flag to ldflags and print version in banner

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
     main: ./main.go
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/yonahd/kor/pkg/utils.Version={{.Version}}
     goos:
       - linux
     goarch:
@@ -17,6 +19,8 @@ builds:
     main: ./main.go
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/yonahd/kor/pkg/utils.Version={{.Version}}
     goos:
       - darwin
     goarch:
@@ -32,7 +36,7 @@ builds:
       - amd64
     ldflags:
       - -buildmode=exe
-
+      - -X github.com/yonahd/kor/pkg/utils.Version={{.Version}}
 archives:
   - format: tar.gz
     name_template: >-
@@ -57,3 +61,5 @@ changelog:
       - 'README'
       - Merge pull request
       - Merge branch
+snapshot:
+  name_template: "{{ .Version }}"

--- a/pkg/utils/banner.go
+++ b/pkg/utils/banner.go
@@ -1,8 +1,12 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/fatih/color"
 )
+
+var Version = "dev"
 
 func PrintLogo(outputFormat string) {
 	boldBlue := color.New(color.FgHiBlue, color.Bold)
@@ -15,7 +19,7 @@ func PrintLogo(outputFormat string) {
 `
 	// processing of the `outputFormat` happens inside of the rootCmd so this requires a pretty large change
 	// to keep the banner. Instead just loop through os args and find if the format was set and handle it there
-
+	fmt.Printf("version: v%s\n", Version)
 	if outputFormat != "yaml" && outputFormat != "json" {
 		boldBlue.Println(asciiLogo)
 	}


### PR DESCRIPTION
![image](https://github.com/yonahd/kor/assets/77291662/654bb915-5b22-47ac-8f97-6421d4a460ed)

to generate binaries i ran the following command
```shell
goreleaser --snapshot --skip-publish --clean
```

I have tested the binaries for the following:
1. darwin - arm64
2. linux - amd64
3. windows 