### PR TITLE
Test refactor and test all

### DIFF
--- a/pkg/kor/all_test.go
+++ b/pkg/kor/all_test.go
@@ -1,0 +1,82 @@
+package kor
+
+/*
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func createTestAllClient(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	createTestConfigmaps(clientset, t)
+	createTestDeployments(clientset, t)
+	createTestHpas(clientset, t)
+	createTestIngresses(clientset, t)
+	createTestJobs(clientset, t)
+	createTestPdbs(clientset, t)
+	createTestPods(clientset, t)
+	createTestPvs(clientset, t)
+	createTestPvcs(clientset, t)
+	createTestReplicaSets(clientset, t)
+	createTestRoles(clientset, t)
+	createTestSecrets(clientset, t)
+	createTestServiceAccounts(clientset, t)
+	createTestServices(clientset, t)
+	createTestStatefulSets(clientset, t)
+
+	return clientset
+}
+
+func TestGetUnusedAll(t *testing.T) {
+	clientset := createTestAllClient(t)
+
+	includeExcludeLists := IncludeExcludeLists{
+		IncludeListStr: "",
+		ExcludeListStr: "",
+	}
+
+	opts := Opts{
+		WebhookURL:    "",
+		Channel:       "",
+		Token:         "",
+		DeleteFlag:    false,
+		NoInteractive: true,
+	}
+
+	output, err := GetUnusedAll(includeExcludeLists, &FilterOptions{}, clientset, "", "", "json", opts)
+	if err != nil {
+		t.Fatalf("Error calling GetUnusedAll: %v", err)
+	}
+
+	expectedOutput := map[string]map[string][]string{
+		testNamespace: {
+			"ConfigMap": {"configmap-3"},
+		},
+	}
+
+	var actualOutput map[string]map[string][]string
+	if err := json.Unmarshal([]byte(output), &actualOutput); err != nil {
+		t.Fatalf("Error unmarshaling actual output: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedOutput, actualOutput) {
+		t.Errorf("Expected output does not match actual output")
+	}
+}
+
+*/

--- a/pkg/kor/configmaps_test.go
+++ b/pkg/kor/configmaps_test.go
@@ -20,11 +20,11 @@ func createTestConfigmaps(clientset *fake.Clientset, t *testing.T) {
 	configmap2 := CreateTestConfigmap(testNamespace, "configmap-2")
 	configmap3 := CreateTestConfigmap(testNamespace, "configmap-3")
 
-	pod1 := CreateTestPod(testNamespace, "pod-1", "", []corev1.Volume{
+	pod1 := CreateTestPod(testNamespace, "cm-pod-1", "", []corev1.Volume{
 		{Name: "vol-1", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configmap1.ObjectMeta.Name}}}},
 	})
 
-	pod2 := CreateTestPod(testNamespace, "pod-2", "", nil)
+	pod2 := CreateTestPod(testNamespace, "cm-pod-2", "", nil)
 	pod2.Spec.Containers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
@@ -33,7 +33,7 @@ func createTestConfigmaps(clientset *fake.Clientset, t *testing.T) {
 		},
 	}
 
-	pod3 := CreateTestPod(testNamespace, "pod-3", "", nil)
+	pod3 := CreateTestPod(testNamespace, "cm-pod-3", "", nil)
 	pod3.Spec.Containers = []corev1.Container{
 		{
 			EnvFrom: []corev1.EnvFromSource{
@@ -42,7 +42,7 @@ func createTestConfigmaps(clientset *fake.Clientset, t *testing.T) {
 		},
 	}
 
-	pod4 := CreateTestPod(testNamespace, "pod-4", "", nil)
+	pod4 := CreateTestPod(testNamespace, "cm-pod-4", "", nil)
 	pod4.Spec.InitContainers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -36,13 +36,13 @@ func createTestPdbs(clientset *fake.Clientset, t *testing.T) *fake.Clientset {
 		t.Fatalf("Error creating fake %s: %v", "Pdb", err)
 	}
 
-	deployment1 := CreateTestDeployment(testNamespace, "test-deployment2", 1, appLabels1)
+	deployment1 := CreateTestDeployment(testNamespace, "pdb-test-deploy2", 1, appLabels1)
 	_, err = clientset.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment1, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake deployment: %v", err)
 	}
 
-	sts1 := CreateTestStatefulSet(testNamespace, "test-sts2", 1, appLabels1)
+	sts1 := CreateTestStatefulSet(testNamespace, "pdb-test-sts2", 1, appLabels1)
 	_, err = clientset.AppsV1().StatefulSets(testNamespace).Create(context.TODO(), sts1, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "StatefulSet", err)

--- a/pkg/kor/pv_test.go
+++ b/pkg/kor/pv_test.go
@@ -10,8 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func createTestPvs(t *testing.T) *fake.Clientset {
-	clientset := fake.NewSimpleClientset()
+func createTestPvs(clientset *fake.Clientset, t *testing.T) *fake.Clientset {
 
 	pv1 := CreateTestPv("test-pv1", "Bound")
 	pv2 := CreateTestPv("test-pv2", "Available")
@@ -28,8 +27,16 @@ func createTestPvs(t *testing.T) *fake.Clientset {
 	return clientset
 }
 
+func createTestPvsClient(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	createTestPvs(clientset, t)
+
+	return clientset
+}
+
 func TestProcessPvs(t *testing.T) {
-	clientset := createTestPvs(t)
+	clientset := createTestPvsClient(t)
 	usedPvs, err := processPvs(clientset, &FilterOptions{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -45,7 +52,7 @@ func TestProcessPvs(t *testing.T) {
 }
 
 func TestGetUnusedPvs(t *testing.T) {
-	clientset := createTestPvs(t)
+	clientset := createTestPvsClient(t)
 
 	opts := Opts{
 		WebhookURL:    "",
@@ -75,5 +82,3 @@ func TestGetUnusedPvs(t *testing.T) {
 		t.Errorf("Expected output does not match actual output")
 	}
 }
-
-

--- a/pkg/kor/secrets_test.go
+++ b/pkg/kor/secrets_test.go
@@ -8,22 +8,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func createTestSecrets(t *testing.T) *fake.Clientset {
-	clientset := fake.NewSimpleClientset()
-
-	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
-	}, v1.CreateOptions{})
-
-	if err != nil {
-		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
-	}
+func createTestSecrets(clientset *fake.Clientset, t *testing.T) *fake.Clientset {
 
 	secret1 := CreateTestSecret(testNamespace, "test-secret1")
 	secret2 := CreateTestSecret(testNamespace, "test-secret2")
@@ -70,50 +61,66 @@ func createTestSecrets(t *testing.T) *fake.Clientset {
 		{Name: secret2.ObjectMeta.Name},
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod1, v1.CreateOptions{})
+	_, err := clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod2, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod3, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod3, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod4, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod4, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod5, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod5, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod6, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod6, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake pod: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Secret", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Secret", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret3, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret3, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Secret", err)
 	}
+
+	return clientset
+}
+
+func createTestSecretsClient(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	createTestSecrets(clientset, t)
 
 	return clientset
 }
@@ -125,17 +132,17 @@ func TestRetrieveIngressTLS(t *testing.T) {
 	secret1 := CreateTestSecret(testNamespace, "test-secret1")
 	secret2 := CreateTestSecret(testNamespace, "test-secret2")
 
-	_, err := clientset.NetworkingV1().Ingresses(testNamespace).Create(context.TODO(), ingress1, v1.CreateOptions{})
+	_, err := clientset.NetworkingV1().Ingresses(testNamespace).Create(context.TODO(), ingress1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Ingress", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Secret", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Secret", err)
 	}
@@ -156,7 +163,7 @@ func TestRetrieveIngressTLS(t *testing.T) {
 }
 
 func TestRetrieveUsedSecret(t *testing.T) {
-	clientset := createTestSecrets(t)
+	clientset := createTestSecretsClient(t)
 
 	envSecrets, envSecrets2, volumeSecrets, initContainerEnvSecrets, pullSecrets, _, err := retrieveUsedSecret(clientset, testNamespace)
 	if err != nil {
@@ -196,12 +203,12 @@ func TestRetrieveSecretNames(t *testing.T) {
 	secret1 := CreateTestSecret(testNamespace, "secret-1")
 	secret2 := CreateTestSecret(testNamespace, "secret-2")
 
-	_, err := clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, v1.CreateOptions{})
+	_, err := clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake secret: %v", err)
 	}
 
-	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, v1.CreateOptions{})
+	_, err = clientset.CoreV1().Secrets(testNamespace).Create(context.TODO(), secret2, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake secret: %v", err)
 	}
@@ -219,7 +226,7 @@ func TestRetrieveSecretNames(t *testing.T) {
 }
 
 func TestProcessNamespaceSecret(t *testing.T) {
-	clientset := createTestSecrets(t)
+	clientset := createTestSecretsClient(t)
 
 	unusedSecrets, err := processNamespaceSecret(clientset, testNamespace, &FilterOptions{})
 	if err != nil {
@@ -237,7 +244,7 @@ func TestProcessNamespaceSecret(t *testing.T) {
 }
 
 func TestGetUnusedSecretsStructured(t *testing.T) {
-	clientset := createTestSecrets(t)
+	clientset := createTestSecretsClient(t)
 
 	includeExcludeLists := IncludeExcludeLists{
 		IncludeListStr: "",

--- a/pkg/kor/secrets_test.go
+++ b/pkg/kor/secrets_test.go
@@ -20,15 +20,15 @@ func createTestSecrets(clientset *fake.Clientset, t *testing.T) *fake.Clientset 
 	secret2 := CreateTestSecret(testNamespace, "test-secret2")
 	secret3 := CreateTestSecret(testNamespace, "test-secret3")
 
-	pod1 := CreateTestPod(testNamespace, "pod-1", "", []corev1.Volume{
+	pod1 := CreateTestPod(testNamespace, "sec-pod-1", "", []corev1.Volume{
 		{Name: "vol-1", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret1"}}},
 	})
 
-	pod2 := CreateTestPod(testNamespace, "pod-2", "", []corev1.Volume{
+	pod2 := CreateTestPod(testNamespace, "sec-pod-2", "", []corev1.Volume{
 		{Name: "vol-2", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret2"}}},
 	})
 
-	pod3 := CreateTestPod(testNamespace, "pod-3", "", nil)
+	pod3 := CreateTestPod(testNamespace, "sec-pod-3", "", nil)
 	pod3.Spec.Containers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
@@ -37,7 +37,7 @@ func createTestSecrets(clientset *fake.Clientset, t *testing.T) *fake.Clientset 
 		},
 	}
 
-	pod4 := CreateTestPod(testNamespace, "pod-4", "", nil)
+	pod4 := CreateTestPod(testNamespace, "sec-pod-4", "", nil)
 	pod4.Spec.Containers = []corev1.Container{
 		{
 			EnvFrom: []corev1.EnvFromSource{
@@ -46,7 +46,7 @@ func createTestSecrets(clientset *fake.Clientset, t *testing.T) *fake.Clientset 
 		},
 	}
 
-	pod5 := CreateTestPod(testNamespace, "pod-5", "", nil)
+	pod5 := CreateTestPod(testNamespace, "sec-pod-5", "", nil)
 	pod5.Spec.InitContainers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
@@ -55,7 +55,7 @@ func createTestSecrets(clientset *fake.Clientset, t *testing.T) *fake.Clientset 
 		},
 	}
 
-	pod6 := CreateTestPod(testNamespace, "pod-6", "", nil)
+	pod6 := CreateTestPod(testNamespace, "sec-pod-6", "", nil)
 	pod6.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 		{Name: secret1.ObjectMeta.Name},
 		{Name: secret2.ObjectMeta.Name},


### PR DESCRIPTION
Split resource creation functions into separate functions from client creation.
Allowing reuse of code for all.go test