### PR TITLE
refactor: remove unused "resourceMap" from GetUnusedCrds func

### DIFF
--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -65,9 +65,6 @@ func GetUnusedCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient 
 	if output != "" {
 		outputBuffer.WriteString(output)
 		outputBuffer.WriteString("\n")
-
-		resourceMap := make(map[string][]string)
-		resourceMap["Crd"] = diff
 	}
 
 	jsonResponse, err := json.MarshalIndent(response, "", "  ")


### PR DESCRIPTION
 remove unused "resourceMap" from GetUnusedCrds func