### PR TITLE
Fix: refactored mismatching deletion resource types

### DIFF
--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -45,7 +45,7 @@ func DeleteResourceCmd() map[string]func(clientset kubernetes.Interface, namespa
 		"PDB": func(clientset kubernetes.Interface, namespace, name string) error {
 			return clientset.PolicyV1beta1().PodDisruptionBudgets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 		},
-		"Roles": func(clientset kubernetes.Interface, namespace, name string) error {
+		"Role": func(clientset kubernetes.Interface, namespace, name string) error {
 			return clientset.RbacV1().Roles(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 		},
 		"PVC": func(clientset kubernetes.Interface, namespace, name string) error {
@@ -134,7 +134,7 @@ func updateResource(clientset kubernetes.Interface, namespace, resourceType stri
 		return clientset.NetworkingV1().Ingresses(namespace).Update(context.TODO(), resource.(*networkingv1.Ingress), metav1.UpdateOptions{})
 	case "PDB":
 		return clientset.PolicyV1beta1().PodDisruptionBudgets(namespace).Update(context.TODO(), resource.(*policyv1beta1.PodDisruptionBudget), metav1.UpdateOptions{})
-	case "Roles":
+	case "Role":
 		return clientset.RbacV1().Roles(namespace).Update(context.TODO(), resource.(*rbacv1.Role), metav1.UpdateOptions{})
 	case "PVC":
 		return clientset.CoreV1().PersistentVolumeClaims(namespace).Update(context.TODO(), resource.(*corev1.PersistentVolumeClaim), metav1.UpdateOptions{})
@@ -170,7 +170,7 @@ func getResource(clientset kubernetes.Interface, namespace, resourceType, resour
 		return clientset.NetworkingV1().Ingresses(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 	case "PDB":
 		return clientset.PolicyV1beta1().PodDisruptionBudgets(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
-	case "Roles":
+	case "Role":
 		return clientset.RbacV1().Roles(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 	case "PVC":
 		return clientset.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -155,7 +155,7 @@ func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.
 		}
 
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource(diff, clientset, namespace, "Serviceaccount", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Serviceaccount %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -46,7 +46,7 @@ func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Int
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource(diff, clientset, namespace, "Statefulset", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Statefulset %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/statefulsets_test.go
+++ b/pkg/kor/statefulsets_test.go
@@ -8,7 +8,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -53,7 +53,7 @@ func TestProcessNamespaceStatefulSets(t *testing.T) {
 	}
 
 	if len(statefulSetsWithoutReplicas) != 1 {
-		t.Errorf("Expected 1 deployment without replicas, got %d", len(statefulSetsWithoutReplicas))
+		t.Errorf("Expected 1 statefulSet without replicas, got %d", len(statefulSetsWithoutReplicas))
 	}
 
 	if statefulSetsWithoutReplicas[0] != "test-sts1" {


### PR DESCRIPTION
In cases where the resource type name mismatches in the following funcs, its deletion functionality will break:
```
# pkg/kor/<resource>s.go

func GetUnused<Resource>s()
	if opts.DeleteFlag {
          if diff, err = DeleteResource(diff, clientset, namespace, "<Resource>", opts.NoInteractive); err != nil {
          
# pkg/kor/delete.go

func DeleteResourceCmd()
        "<Resource>": func(clientset kubernetes.Interface, namespace, name string) error {
```

I've fixed the following mismatches in order to resolve #200:
- `delete.go` -> changed `Roles` to `Role` to match passed resource-type in `roles.go`.
- `serviceaccountss.go` -> changed `Serviceaccount` to `ServiceAccount`.
- `statefulsets.go` -> changed `Statefulset` to `StatefulSet`.