### PR TITLE
Refactor: added missing resources and separated cluster-scoped resources

### DIFF
--- a/charts/kor/templates/role.yaml
+++ b/charts/kor/templates/role.yaml
@@ -10,7 +10,6 @@ rules:
     resources:
       - pods
       - configmaps
-      - namespaces
       - secrets
       - services
       - serviceaccounts
@@ -18,13 +17,13 @@ rules:
       - statefulsets
       - roles
       - rolebindings
-      - clusterroles
-      - clusterrolebindings
       - horizontalpodautoscalers
       - persistentvolumeclaims
       - ingresses
       - poddisruptionbudgets
       - endpoints
+      - jobs
+      - replicasets
     verbs:
       - get
       - list
@@ -41,7 +40,6 @@ rules:
     resources:
       - pods
       - configmaps
-      - namespaces
       - secrets
       - services
       - serviceaccounts
@@ -49,13 +47,19 @@ rules:
       - statefulsets
       - roles
       - rolebindings
-      - clusterroles
-      - clusterrolebindings
       - horizontalpodautoscalers
       - persistentvolumeclaims
       - ingresses
       - poddisruptionbudgets
       - endpoints
+      - jobs
+      - replicasets
+      {{/* cluster-scoped resources */}}
+      - namespaces
+      - clusterroles
+      - clusterrolebindings
+      - persistentvolumes
+      - customresourcedefinitions
     verbs:
       - get
       - list


### PR DESCRIPTION
The following resources were missing from the `kor` Helm chart RBAC:
- jobs
- replicasets
- persistentvolumes
- customresourcedefinitions

In addition, the following resources are cluster-scoped and won't have any effect when listed under `read-resources-role`, only under `read-resources-clusterrole`:
- namespaces
- clusterroles
- clusterrolebindings