### PR TITLE
Feat: Added version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --exclude-namespaces strings   Namespaces to be excluded, split by commas. Example: --exclude-namespace ns1,ns2,ns3. If --include-namespace is set, --exclude-namespaces will be ignored.
   -h, --help                         help for kor
       --include-labels string        Selector to filter in, Example: --include-labels key1=value1,key2=value2.
-  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespace ns1,ns2,ns3. 
+  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespace ns1,ns2,ns3.
   -k, --kubeconfig string            Path to kubeconfig file (optional)
       --newer-than string            The maximum age of the resources to be considered unused. This flag cannot be used together with older-than flag. Example: --newer-than=1h2m
       --no-interactive               Do not prompt for confirmation when deleting resources. Be careful using this flag!
@@ -119,7 +119,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --slack-channel string         Slack channel to send notifications to. --slack-channel requires --slack-auth-token to be set.
       --slack-webhook-url string     Slack webhook URL to send notifications to
   -v, --verbose                      Verbose output (print empty namespaces)
-
+      --version                      version for kor
 ```
 
 To use a specific subcommand, run `kor [subcommand] [flags]`.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
 - `daemonsets`- Gets unused DaemonSets for the specified namespace or all namespaces.
 - `finalizers` - Gets unused pending deletion resources for the specified namespace or all namespaces.
 - `exporter` - Export Prometheus metrics.
+- `version` - Print kor version information.
 
 ### Supported Flags
 ```
@@ -119,7 +120,6 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --slack-channel string         Slack channel to send notifications to. --slack-channel requires --slack-auth-token to be set.
       --slack-webhook-url string     Slack webhook URL to send notifications to
   -v, --verbose                      Verbose output (print empty namespaces)
-      --version                      version for kor
 ```
 
 To use a specific subcommand, run `kor [subcommand] [flags]`.

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -12,8 +12,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "kor",
-	Short: "kor - a CLI to to discover unused Kubernetes resources",
+	Use:     "kor",
+	Version: "v" + utils.Version,
+	Short:   "kor - a CLI to to discover unused Kubernetes resources",
 	Long: `kor is a CLI to to discover unused Kubernetes resources
 	kor can currently discover unused configmaps and secrets`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -12,9 +12,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "kor",
-	Version: "v" + utils.Version,
-	Short:   "kor - a CLI to to discover unused Kubernetes resources",
+	Use:   "kor",
+	Short: "kor - a CLI to to discover unused Kubernetes resources",
 	Long: `kor is a CLI to to discover unused Kubernetes resources
 	kor can currently discover unused configmaps and secrets`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/kor/version.go
+++ b/cmd/kor/version.go
@@ -1,0 +1,20 @@
+package kor
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/yonahd/kor/pkg/utils"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print kor version information",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.PrintVersion()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/pkg/utils/banner.go
+++ b/pkg/utils/banner.go
@@ -8,19 +8,23 @@ import (
 
 var Version = "dev"
 
+func PrintVersion() {
+	fmt.Printf("kor version: v%s\n", Version)
+}
+
 func PrintLogo(outputFormat string) {
 	boldBlue := color.New(color.FgHiBlue, color.Bold)
 	asciiLogo := `
-  _  _____  ____  
- | |/ / _ \|  _ \ 
+  _  _____  ____
+ | |/ / _ \|  _ \
  | ' / | | | |_) |
- | . \ |_| |  _ < 
+ | . \ |_| |  _ <
  |_|\_\___/|_| \_\
 `
 	// processing of the `outputFormat` happens inside of the rootCmd so this requires a pretty large change
 	// to keep the banner. Instead just loop through os args and find if the format was set and handle it there
 	if outputFormat != "yaml" && outputFormat != "json" {
-		fmt.Printf("version: v%s\n", Version) 
+		PrintVersion()
 		boldBlue.Println(asciiLogo)
 	}
 }


### PR DESCRIPTION
Added `version` subcommand for users to view `kor` version not through querying commands (banner display).

```
$ kor version
kor version: v<release>
```