### PR TITLE
feat: unused StorageClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Kor is a tool to discover unused Kubernetes resources. Currently, Kor can identi
 - Jobs
 - ReplicaSets
 - DaemonSets
+- StorageClasses
 
 ![Kor Screenshot](/images/screenshot.png)
 
@@ -92,10 +93,11 @@ Kor provides various subcommands to identify and list unused resources. The avai
 - `hpa` - Gets unused HPAs for the specified namespace or all namespaces.
 - `pods` - Gets unused Pods for the specified namespace or all namespaces.
 - `pvc` - Gets unused PVCs for the specified namespace or all namespaces.
-- `pv` - Gets unused PVs in the cluster(non namespaced resource).
+- `pv` - Gets unused PVs in the cluster (non namespaced resource).
+- `storageclasses` - Gets unused StorageClasses in the cluster (non namespaced resource).
 - `ingress` - Gets unused Ingresses for the specified namespace or all namespaces.
 - `pdb` - Gets unused PDBs for the specified namespace or all namespaces.
-- `crd` - Gets unused CRDs in the cluster(non namespaced resource).
+- `crd` - Gets unused CRDs in the cluster (non namespaced resource).
 - `jobs` - Gets unused jobs for the specified namespace or all namespaces.
 - `replicasets` - Gets unused replicaSets for the specified namespace or all namespaces.
 - `daemonsets`- Gets unused DaemonSets for the specified namespace or all namespaces.
@@ -155,6 +157,7 @@ kor [subcommand] --help
 | Jobs            | Jobs status is completed                                                                                                                                                                                                          |                                                                                                                              |
 | ReplicaSets     | replicaSets that specify replicas to 0 and has already completed it's work                                                                                                                                                        |
 | DaemonSets     | DaemonSets not scheduled on any nodes              |
+| StorageClasses | StorageClasses not used by any PVs/PVCs |
 
 ## Deleting Unused resources
 If you want to delete resources in an interactive way using Kor you can run:

--- a/charts/kor/templates/role.yaml
+++ b/charts/kor/templates/role.yaml
@@ -55,13 +55,14 @@ rules:
       - endpoints
       - jobs
       - replicasets
-      - daemonsets      
+      - daemonsets
       {{/* cluster-scoped resources */}}
       - namespaces
       - clusterroles
       - clusterrolebindings
       - persistentvolumes
       - customresourcedefinitions
+      - storageclasses
     verbs:
       - get
       - list

--- a/cmd/kor/storageclasses.go
+++ b/cmd/kor/storageclasses.go
@@ -1,0 +1,32 @@
+package kor
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yonahd/kor/pkg/kor"
+	"github.com/yonahd/kor/pkg/utils"
+)
+
+var scCmd = &cobra.Command{
+	Use:     "storageclass",
+	Aliases: []string{"sc", "storageclassses"},
+	Short:   "Gets unused storageClasses",
+	Args:    cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		clientset := kor.GetKubeClient(kubeconfig)
+
+		if response, err := kor.GetUnusedStorageClasses(filterOptions, clientset, outputFormat, opts); err != nil {
+			fmt.Println(err)
+		} else {
+			utils.PrintLogo(outputFormat)
+			fmt.Println(response)
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(scCmd)
+}

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -185,6 +185,15 @@ func getUnusedDaemonSets(clientset kubernetes.Interface, namespace string, filte
 	return namespaceSADiff
 }
 
+func getUnusedStorageClasses(clientset kubernetes.Interface, filterOpts *filters.Options) ResourceDiff {
+	scDiff, err := processStorageClasses(clientset, filterOpts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get %s: %v\n", "StorageClasses", err)
+	}
+	allScDiff := ResourceDiff{"StorageClass", scDiff}
+	return allScDiff
+}
+
 func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
 	var outputBuffer bytes.Buffer
 
@@ -253,6 +262,12 @@ func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, a
 	outputBuffer.WriteString(clusterRoleOutput)
 	outputBuffer.WriteString("\n")
 	noNamespaceResourceMap[clusterRoleDiff.resourceType] = clusterRoleDiff.diff
+
+	storageClassDiff := getUnusedStorageClasses(clientset, filterOpts)
+	storageClassOutput := FormatOutputAll("", []ResourceDiff{storageClassDiff}, opts)
+	outputBuffer.WriteString(storageClassOutput)
+	outputBuffer.WriteString("\n")
+	noNamespaceResourceMap[storageClassDiff.resourceType] = storageClassDiff.diff
 
 	output := FormatOutputAll("", allDiffs, opts)
 

--- a/pkg/kor/create_test_resources.go
+++ b/pkg/kor/create_test_resources.go
@@ -8,7 +8,8 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -219,25 +220,40 @@ func CreateTestIngress(namespace, name, ServiceName, secretName string, labels m
 	}
 }
 
-func CreateTestPvc(namespace, name string, labels map[string]string) *corev1.PersistentVolumeClaim {
+func CreateTestPvc(namespace, name string, labels map[string]string, storageClass string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 			Labels:    labels,
 		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+		},
 	}
 }
 
-func CreateTestPv(name, phase string, labels map[string]string) *corev1.PersistentVolume {
+func CreateTestPv(name, phase string, labels map[string]string, storageClass string) *corev1.PersistentVolume {
 	return &corev1.PersistentVolume{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
+		Spec: corev1.PersistentVolumeSpec{
+			StorageClassName: storageClass,
+		},
 		Status: corev1.PersistentVolumeStatus{
 			Phase: corev1.PersistentVolumePhase(phase),
 		},
+	}
+}
+
+func CreateTestStorageClass(name, provisioner string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner,
 	}
 }
 

--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -15,6 +15,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,6 +75,9 @@ func DeleteResourceCmd() map[string]func(clientset kubernetes.Interface, namespa
 		},
 		"DaemonSet": func(clientset kubernetes.Interface, namespace, name string) error {
 			return clientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		},
+		"StorageClass": func(clientset kubernetes.Interface, namespace, name string) error {
+			return clientset.StorageV1().StorageClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
 		},
 	}
 
@@ -160,6 +164,8 @@ func updateResource(clientset kubernetes.Interface, namespace, resourceType stri
 		return clientset.AppsV1().ReplicaSets(namespace).Update(context.TODO(), resource.(*appsv1.ReplicaSet), metav1.UpdateOptions{})
 	case "DaemonSet":
 		return clientset.AppsV1().DaemonSets(namespace).Update(context.TODO(), resource.(*appsv1.DaemonSet), metav1.UpdateOptions{})
+	case "StorageClass":
+		return clientset.StorageV1().StorageClasses().Update(context.TODO(), resource.(*storagev1.StorageClass), metav1.UpdateOptions{})
 	}
 	return nil, fmt.Errorf("resource type '%s' is not supported", resourceType)
 }
@@ -200,6 +206,8 @@ func getResource(clientset kubernetes.Interface, namespace, resourceType, resour
 		return clientset.AppsV1().ReplicaSets(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 	case "DaemonSet":
 		return clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
+	case "StorageClass":
+		return clientset.StorageV1().StorageClasses().Get(context.TODO(), resourceName, metav1.GetOptions{})
 	}
 	return nil, fmt.Errorf("resource type '%s' is not supported", resourceType)
 }

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -33,6 +33,10 @@ func retrieveNoNamespaceDiff(clientset kubernetes.Interface, apiExtClient apiext
 			clusterRoleDiff := getUnusedClusterRoles(clientset, filterOpts)
 			noNamespaceDiff = append(noNamespaceDiff, clusterRoleDiff)
 			markedForRemoval[counter] = true
+		case "sc", "storageclass", "storageclasses":
+			storageClassDiff := getUnusedStorageClasses(clientset, filterOpts)
+			noNamespaceDiff = append(noNamespaceDiff, storageClassDiff)
+			markedForRemoval[counter] = true
 		}
 	}
 

--- a/pkg/kor/pv_test.go
+++ b/pkg/kor/pv_test.go
@@ -15,25 +15,25 @@ import (
 func createTestPvs(t *testing.T) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 
-	pv1 := CreateTestPv("test-pv1", "Bound", AppLabels)
+	pv1 := CreateTestPv("test-pv1", "Bound", AppLabels, "test-sc1")
 	_, err := clientset.CoreV1().PersistentVolumes().Create(context.TODO(), pv1, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "PV", err)
 	}
 
-	pv2 := CreateTestPv("test-pv2", "Available", AppLabels)
+	pv2 := CreateTestPv("test-pv2", "Available", AppLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), pv2, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "PV", err)
 	}
 
-	pv3 := CreateTestPv("test-pv3", "Bound", UsedLabels)
+	pv3 := CreateTestPv("test-pv3", "Bound", UsedLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), pv3, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "PV", err)
 	}
 
-	pv4 := CreateTestPv("test-pv4", "Available", UnusedLabels)
+	pv4 := CreateTestPv("test-pv4", "Available", UnusedLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), pv4, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "PV", err)

--- a/pkg/kor/pvc_test.go
+++ b/pkg/kor/pvc_test.go
@@ -28,25 +28,25 @@ func createTestPvcs(t *testing.T) *fake.Clientset {
 		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
 	}
 
-	pvc1 := CreateTestPvc(testNamespace, "test-pvc1", AppLabels)
+	pvc1 := CreateTestPvc(testNamespace, "test-pvc1", AppLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumeClaims(testNamespace).Create(context.TODO(), pvc1, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Pvc", err)
 	}
 
-	pvc2 := CreateTestPvc(testNamespace, "test-pvc2", AppLabels)
+	pvc2 := CreateTestPvc(testNamespace, "test-pvc2", AppLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumeClaims(testNamespace).Create(context.TODO(), pvc2, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Pvc", err)
 	}
 
-	pvc3 := CreateTestPvc(testNamespace, "test-pvc3", UsedLabels)
+	pvc3 := CreateTestPvc(testNamespace, "test-pvc3", UsedLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumeClaims(testNamespace).Create(context.TODO(), pvc3, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Pvc", err)
 	}
 
-	pvc4 := CreateTestPvc(testNamespace, "test-pvc4", UnusedLabels)
+	pvc4 := CreateTestPvc(testNamespace, "test-pvc4", UnusedLabels, "test-sc1")
 	_, err = clientset.CoreV1().PersistentVolumeClaims(testNamespace).Create(context.TODO(), pvc4, v1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating fake %s: %v", "Pvc", err)

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -1,0 +1,124 @@
+package kor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+
+	"github.com/yonahd/kor/pkg/filters"
+)
+
+func retrieveUsedStorageClasses(clientset kubernetes.Interface) ([]string, error) {
+	pvs, err := clientset.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("Failed to list PVs: %v\n", err)
+		os.Exit(1)
+	}
+
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("Failed to list PVCs: %v\n", err)
+		os.Exit(1)
+	}
+
+	var usedStorageClasses []string
+
+	// Iterate through each PV and check for StorageClass usage
+	for _, pv := range pvs.Items {
+		if pv.Spec.StorageClassName != "" {
+			usedStorageClasses = append(usedStorageClasses, pv.Spec.StorageClassName)
+		}
+	}
+
+	// Iterate through each PVC and check for StorageClass usage
+	for _, pvc := range pvcs.Items {
+		if pvc.Spec.StorageClassName != nil {
+			usedStorageClasses = append(usedStorageClasses, *pvc.Spec.StorageClassName)
+		}
+	}
+
+	return usedStorageClasses, err
+}
+
+func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.Options) ([]string, error) {
+	scs, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
+	if err != nil {
+		return nil, err
+	}
+
+	var unusedStorageClassNames []string
+	storageClassNames := make([]string, 0, len(scs.Items))
+
+	for _, sc := range scs.Items {
+		if pass := filters.KorLabelFilter(&sc, &filters.Options{}); pass {
+			continue
+		}
+
+		if sc.Labels["kor/used"] == "false" {
+			unusedStorageClassNames = append(unusedStorageClassNames, sc.Name)
+			continue
+		}
+
+		storageClassNames = append(storageClassNames, sc.Name)
+	}
+
+	usedStorageClasses, err := retrieveUsedStorageClasses(clientset)
+	if err != nil {
+		return nil, err
+	}
+
+	diff := CalculateResourceDifference(usedStorageClasses, storageClassNames)
+	diff = append(diff, unusedStorageClassNames...)
+	return diff, nil
+}
+
+func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+	var outputBuffer bytes.Buffer
+	response := make(map[string]map[string][]string)
+
+	diff, err := processStorageClasses(clientset, filterOpts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to process storageClasses: %v\n", err)
+	}
+
+	if len(diff) > 0 {
+		// We consider cluster scope resources in "" (empty string) namespace, as it is common in k8s
+		if response[""] == nil {
+			response[""] = make(map[string][]string)
+		}
+		response[""]["StorageClass"] = diff
+	}
+
+	if opts.DeleteFlag {
+		if diff, err = DeleteResource(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete StorageClass %s: %v\n", diff, err)
+		}
+	}
+
+	output := FormatOutput("", diff, "StorageClasses", opts)
+	if output != "" {
+		outputBuffer.WriteString(output)
+		outputBuffer.WriteString("\n")
+
+		response[""]["StorageClass"] = diff
+
+	}
+
+	jsonResponse, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	unusedStorageClasses, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+	}
+
+	return unusedStorageClasses, nil
+}

--- a/pkg/kor/storageclasses_test.go
+++ b/pkg/kor/storageclasses_test.go
@@ -1,0 +1,99 @@
+package kor
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/yonahd/kor/pkg/filters"
+)
+
+func createTestStorageClass(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	sc1 := CreateTestStorageClass("test-sc1", "kor.com")
+	_, err := clientset.StorageV1().StorageClasses().Create(context.TODO(), sc1, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake %s: %v", "StorageClass", err)
+	}
+
+	return clientset
+}
+
+func TestRetrieveUsedStorageClassesFromPVCs(t *testing.T) {
+	clientset := createTestPvcs(t)
+	usedStorageClasses, err := retrieveUsedStorageClasses(clientset)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !contains(usedStorageClasses, "test-sc1") {
+		t.Errorf("Expected 'test-sc1', got %v", usedStorageClasses)
+	}
+}
+
+func TestRetrieveUsedStorageClassesFromPVs(t *testing.T) {
+	clientset := createTestPvs(t)
+	usedStorageClasses, err := retrieveUsedStorageClasses(clientset)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !contains(usedStorageClasses, "test-sc1") {
+		t.Errorf("Expected 'test-sc1', got %v", usedStorageClasses)
+	}
+}
+
+func TestProcessStorageClasses(t *testing.T) {
+	clientset := createTestStorageClass(t)
+	unusedStorageClasses, err := processStorageClasses(clientset, &filters.Options{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if len(unusedStorageClasses) != 1 {
+		t.Errorf("Expected 1 used StorageClasses, got %d", len(unusedStorageClasses))
+	}
+
+	if unusedStorageClasses[0] != "test-sc1" {
+		t.Errorf("Expected 'test-sc1', got %s", unusedStorageClasses[0])
+	}
+}
+
+func TestGetUnusedStorageClassesStructured(t *testing.T) {
+	clientset := createTestStorageClass(t)
+
+	opts := Opts{
+		WebhookURL:    "",
+		Channel:       "",
+		Token:         "",
+		DeleteFlag:    false,
+		NoInteractive: true,
+	}
+
+	output, err := GetUnusedStorageClasses(&filters.Options{}, clientset, "json", opts)
+	if err != nil {
+		t.Fatalf("Error calling GetUnusedStorageClasses: %v", err)
+	}
+
+	expectedOutput := map[string]map[string][]string{
+		"": {
+			"StorageClass": {"test-sc1"},
+		},
+	}
+
+	var actualOutput map[string]map[string][]string
+	if err := json.Unmarshal([]byte(output), &actualOutput); err != nil {
+		t.Fatalf("Error unmarshaling actual output: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedOutput, actualOutput) {
+		t.Errorf("Expected output does not match actual output")
+	}
+}


### PR DESCRIPTION
This PR adds a new functionality to `kor` by finding unused StorageClasses.
I've considered StorageClasses to be unused, if they aren't used by any PVs/PVCs.

```
$ kor storageclass
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused StorageClasses in Namespace:
+---+---------------------+
| # |    RESOURCE NAME    |
+---+---------------------+
| 1 | example-vol-default |
+---+---------------------+

```