### PR TITLE
Feat: Add support for multiple resources in Exporter function

### DIFF
--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -6,6 +6,8 @@ import (
 	"github.com/yonahd/kor/pkg/kor"
 )
 
+var resourceList []string
+
 var exporterCmd = &cobra.Command{
 	Use:   "exporter",
 	Short: "start prometheus exporter",
@@ -15,11 +17,12 @@ var exporterCmd = &cobra.Command{
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
 
-		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts)
+		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList)
 
 	},
 }
 
 func init() {
+	exporterCmd.Flags().StringSliceVarP(&resourceList, "resources", "r", nil, "Comma-separated list of resources to monitor (e.g., deployment,service)")
 	rootCmd.AddCommand(exporterCmd)
 }

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -80,8 +80,9 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 }
 
 func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) (string, error) {
-	if len(resourceList) > 0 {
-		return GetUnusedMulti(strings.Join(resourceList, ","), filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+	if len(resourceList) == 0 || (len(resourceList) == 1 && resourceList[0] == "all") {
+		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 	}
-	return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+	return GetUnusedMulti(strings.Join(resourceList, ","), filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+
 }

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,16 +33,16 @@ func init() {
 }
 
 // TODO: add option to change port / url !?
-func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) {
+func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) {
 	http.Handle("/metrics", promhttp.Handler())
 	fmt.Println("Server listening on :8080")
-	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts) // Start exporting metrics in the background
+	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList) // Start exporting metrics in the background
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		fmt.Println(err)
 	}
 }
 
-func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) {
+func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) {
 	exporterInterval := os.Getenv("EXPORTER_INTERVAL")
 	if exporterInterval == "" {
 		exporterInterval = "10"
@@ -54,7 +55,7 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 
 	for {
 		fmt.Println("collecting unused resources")
-		if korOutput, err := GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
+		if korOutput, err := getUnusedResources(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		} else {
@@ -76,4 +77,11 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 			time.Sleep(time.Duration(exporterIntervalValue) * time.Minute)
 		}
 	}
+}
+
+func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) (string, error) {
+	if len(resourceList) > 0 {
+		return GetUnusedMulti(strings.Join(resourceList, ","), filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+	}
+	return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 }


### PR DESCRIPTION
solves #218
allows you to select which types of unused resources you want to find:
``kor exporter --resources svc,deploy,ing -n namespace`` , can also use `-r` for short.

if resources are not specified it defaults to all resources.