### PR TITLE
Fix: Include unused pods in getUnusedAllNamespaced

### DIFF
--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -220,6 +220,8 @@ func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.In
 		allDiffs = append(allDiffs, namespaceHpaDiff)
 		namespacePvcDiff := getUnusedPvcs(clientset, namespace, filterOpts)
 		allDiffs = append(allDiffs, namespacePvcDiff)
+		namespacePodDiff := getUnusedPods(clientset, namespace, filterOpts)
+		allDiffs = append(allDiffs, namespacePodDiff)
 		namespaceIngressDiff := getUnusedIngresses(clientset, namespace, filterOpts)
 		allDiffs = append(allDiffs, namespaceIngressDiff)
 		namespacePdbDiff := getUnusedPdbs(clientset, namespace, filterOpts)


### PR DESCRIPTION
Added the retrieval of unused pods in the getUnusedAllNamespaced function.
Fixes #230