### PR TITLE
refactor: configure golangci-lint and upgrade github actions

### DIFF
--- a/.github/workflows/merge-request.yml
+++ b/.github/workflows/merge-request.yml
@@ -17,32 +17,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
 
-      - name: Install dependencies
-        run: go get .
-
-      - name: Vet
-        run: go vet ./...
-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
-          skip-pkg-cache: true
+          skip-cache: true
 
       - name: Build
-        run: go build -v ./...
+        run: make build
 
       - name: Test
-        run: go test -v ./... -coverprofile=coverage.txt
+        run: make test
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,21 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
 
-      - name: Install goreleaser
-        run: go install github.com/goreleaser/goreleaser@latest
-
       - name: Run goreleaser
-        run: |
-          goreleaser release
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
         env:
-          GITHUB_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist/**
 main.exe
 coverage.txt
+build/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+run:
+  timeout: 5m
 linters:
   enable:
     - errcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gci
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/yonahd/kor)
+    custom-order: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: *
+
+build:
+	go build -o build/kor main.go
+
+lint:
+	golangci-lint run
+
+lint-fix:
+	golangci-lint run --fix
+
+test:
+	go test -race -coverprofile=coverage.txt -shuffle on ./...

--- a/cmd/kor/clusterroles.go
+++ b/cmd/kor/clusterroles.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/yonahd/kor/pkg/kor"
 	"github.com/yonahd/kor/pkg/utils"
 )

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/yonahd/kor/pkg/filters"
 	v1 "k8s.io/api/rbac/v1"
-	"k8s.io/utils/strings/slices"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/yonahd/kor/pkg/filters"
 )
 
 func retrieveUsedClusterRoles(clientset kubernetes.Interface, filterOpts *filters.Options) ([]string, error) {

--- a/pkg/kor/clusterroles_test.go
+++ b/pkg/kor/clusterroles_test.go
@@ -7,14 +7,14 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/yonahd/kor/pkg/filters"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/yonahd/kor/pkg/filters"
 )
 
 func createTestClusterRoles(t *testing.T) *fake.Clientset {

--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -7,10 +7,9 @@ import (
 	"reflect"
 	"strings"
 
-	batchv1 "k8s.io/api/batch/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"

--- a/pkg/kor/pods_test.go
+++ b/pkg/kor/pods_test.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 


### PR DESCRIPTION
- Setup `golangci-lint` via a configuration file
  - Enabled all [default linters](https://golangci-lint.run/usage/linters/#enabled-by-default) + [gci](https://golangci-lint.run/usage/linters/#gci) (used for custom imports order)
  - Since the `govet` linter is already enabled, I removed the vet step from CI
- Upgraded all GitHub Actions to newer versions
  - Replaced the manual installation and running of `goreleaser` with the official [goreleaser/goreleaser-action](goreleaser/goreleaser-action@v5)
  - Removed the dependencies installation step
- Created `Makefile` to enhance local development and shorten commands for CI

This merge request can be reviewed/merged before https://github.com/yonahd/kor/pull/241.