### PR TITLE
feat: add GKE exceptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on con
 
 ## PR Checklist
 
-- [ ] This PR adds K8 exceptions
+- [ ] This PR adds K8s exceptions (false positives)
 - [ ] This PR add new code
 - [ ] This PR includes test for any new code
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,13 @@
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!
 
+<!--
+  !!!! README !!!! Please fill this out.
+
+  Please follow conventional commit naming conventions:
+
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
+-->
+
 <!-- A short description of what your PR does and what it solves. -->
 
 ## What this PR does / why we need it

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on con
 
 ## PR Checklist
 
-- [ ] This PR adds exceptions
+- [ ] This PR adds K8 exceptions
 - [ ] This PR add new code
 - [ ] This PR includes test for any new code
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on con
 ## PR Checklist
 
 - [ ] This PR adds K8s exceptions (false positives)
-- [ ] This PR add new code
+- [ ] This PR adds new code
 - [ ] This PR includes test for any new code
 
 ## Github Issue

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -78,6 +78,30 @@ var exceptionClusterRoles = []ExceptionResource{
 		ResourceName: "view",
 		Namespace:    "",
 	},
+	{
+		ResourceName: "cloud-provider",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:controller:cloud-node-controller",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:controller:glbc",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:persistent-volume-provisioner",
+		Namespace:    "",
+	},
 }
 
 func retrieveUsedClusterRoles(clientset kubernetes.Interface, filterOpts *filters.Options) ([]string, error) {

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -47,6 +47,46 @@ var exceptionConfigMaps = []ExceptionResource{
 		ResourceName: "cluster-info",
 		Namespace:    "kube-public",
 	},
+	{
+		ResourceName: "config-images",
+		Namespace:    "gmp-system",
+	},
+	{
+		ResourceName: "webhook-ca",
+		Namespace:    "gmp-system",
+	},
+	{
+		ResourceName: "cluster-autoscaler-status",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "cluster-kubestore",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "clustermetrics",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-common-webhook-heartbeat",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "ingress-uid",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "konnectivity-agent-autoscaler-config",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "kube-dns-autoscaler",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "kubedns-config-images",
+		Namespace:    "kube-system",
+	},
 }
 
 func retrieveUsedCM(clientset kubernetes.Interface, namespace string) ([]string, []string, []string, []string, []string, error) {

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -89,6 +89,26 @@ var exceptionCrds = []ExceptionResource{
 		ResourceName: "volumesnapshots.snapshot.storage.k8s.io",
 		Namespace:    "",
 	},
+	{
+		ResourceName: "allowlistedv2workloads.auto.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "allowlistedworkloads.auto.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "backendconfigs.cloud.google.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "clusterrules.monitoring.googleapis.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "frontendconfigs.networking.gke.io",
+		Namespace:    "",
+	},
 }
 
 func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, filterOpts *filters.Options) ([]string, error) {

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -16,6 +16,81 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+var exceptionCrds = []ExceptionResource{
+	{
+		ResourceName: "capacityrequests.internal.autoscaling.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "clusterpodmonitorings.monitoring.googleapis.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "clusterrules.monitoring.googleapis.com ",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "frontendconfigs.networking.gke.io ",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "gkenetworkparamsets.networking.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "globalrules.monitoring.googleapis.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "managedcertificates.networking.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "memberships.hub.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "networks.networking.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "podmonitorings.monitoring.googleapis.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "provisioningrequests.autoscaling.x-k8s.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "rules.monitoring.googleapis.com",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "serviceattachments.networking.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "servicenetworkendpointgroups.networking.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "updateinfos.nodemanagement.gke.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "volumesnapshotclasses.snapshot.storage.k8s.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "volumesnapshotcontents.snapshot.storage.k8s.io",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "volumesnapshots.snapshot.storage.k8s.io",
+		Namespace:    "",
+	},
+}
+
 func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, filterOpts *filters.Options) ([]string, error) {
 
 	var unusedCRDs []string
@@ -27,6 +102,9 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 
 	for _, crd := range crds.Items {
 		if pass := filters.KorLabelFilter(&crd, &filters.Options{}); pass {
+			continue
+		}
+		if isResourceException(crd.Name, "", exceptionCrds) {
 			continue
 		}
 

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -104,7 +104,7 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 		if pass := filters.KorLabelFilter(&crd, &filters.Options{}); pass {
 			continue
 		}
-		if isResourceException(crd.Name, "", exceptionCrds) {
+		if isResourceException(crd.Name, crd.Namespace, exceptionCrds) {
 			continue
 		}
 

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -26,11 +26,11 @@ var exceptionCrds = []ExceptionResource{
 		Namespace:    "",
 	},
 	{
-		ResourceName: "clusterrules.monitoring.googleapis.com ",
+		ResourceName: "clusterrules.monitoring.googleapis.com",
 		Namespace:    "",
 	},
 	{
-		ResourceName: "frontendconfigs.networking.gke.io ",
+		ResourceName: "frontendconfigs.networking.gke.io",
 		Namespace:    "",
 	},
 	{
@@ -99,14 +99,6 @@ var exceptionCrds = []ExceptionResource{
 	},
 	{
 		ResourceName: "backendconfigs.cloud.google.com",
-		Namespace:    "",
-	},
-	{
-		ResourceName: "clusterrules.monitoring.googleapis.com",
-		Namespace:    "",
-	},
-	{
-		ResourceName: "frontendconfigs.networking.gke.io",
 		Namespace:    "",
 	},
 }

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -112,7 +112,7 @@ func ProcessNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 		if pass, _ := filter.SetObject(&daemonSet).Run(filterOpts); pass {
 			continue
 		}
-		if isResourceException(daemonSet.Name, "", exceptionDaemonSets) {
+		if isResourceException(daemonSet.Name, daemonSet.Namespace, exceptionDaemonSets) {
 			continue
 		}
 

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -13,6 +13,93 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+var exceptionDaemonSets = []ExceptionResource{
+	{
+		ResourceName: "kube-proxy",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "fluentbit-gke-256pd",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "fluentbit-gke-max",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-10",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-100",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-20",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-200",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-50",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-scaling-500",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "gke-metrics-agent-windows",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "metadata-proxy-v0.1",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nccl-fastsocket-installer",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-large-cos",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-large-ubuntu",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-medium-cos",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-medium-ubuntu",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-small-cos",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "nvidia-gpu-device-plugin-small-ubuntu",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "pdcsi-node-windows",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "runsc-metric-server",
+		Namespace:    "kube-system",
+	},
+	{
+		ResourceName: "tpu-device-plugin",
+		Namespace:    "kube-system",
+	},
+}
+
 func ProcessNamespaceDaemonSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	daemonSetsList, err := clientset.AppsV1().DaemonSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
@@ -23,6 +110,9 @@ func ProcessNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 
 	for _, daemonSet := range daemonSetsList.Items {
 		if pass, _ := filter.SetObject(&daemonSet).Run(filterOpts); pass {
+			continue
+		}
+		if isResourceException(daemonSet.Name, "", exceptionDaemonSets) {
 			continue
 		}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -13,19 +13,6 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-// These replica sets generated for default GKE
-// TODO: Need to add it the ability for isResourceException to handle regex/wildcard matching
-// var exceptionReplicaSets = []ExceptionResource{
-// 	{
-// 		ResourceName: "metrics-server-v0.6.3-7cb4458849",
-// 		Namespace:    "gmp-system",
-// 	},
-// 	{
-// 		ResourceName: "metrics-server-v0.6.3-7cb4458849",
-// 		Namespace:    "kube-system",
-// 	},
-// }
-
 func ProcessNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	replicaSetList, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -13,6 +13,19 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+// These replica sets generated for default GKE
+// TODO: Need to add it the ability for isResourceException to handle regex/wildcard matching
+// var exceptionReplicaSets = []ExceptionResource{
+// 	{
+// 		ResourceName: "metrics-server-v0.6.3-7cb4458849",
+// 		Namespace:    "gmp-system",
+// 	},
+// 	{
+// 		ResourceName: "metrics-server-v0.6.3-7cb4458849",
+// 		Namespace:    "kube-system",
+// 	},
+// }
+
 func ProcessNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	replicaSetList, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -14,6 +14,17 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+var exceptionRoles = []ExceptionResource{
+	{
+		ResourceName: "cloud-provider",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "system:controller:glbc",
+		Namespace:    "",
+	},
+}
+
 func retrieveUsedRoles(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	// Get a list of all role bindings in the specified namespace
 	roleBindings, err := clientset.RbacV1().RoleBindings(namespace).List(context.TODO(), metav1.ListOptions{})
@@ -51,6 +62,10 @@ func retrieveRoleNames(clientset kubernetes.Interface, namespace string, filterO
 		}
 		if role.Labels["kor/used"] == "false" {
 			unusedRoleNames = append(unusedRoleNames, role.Name)
+			continue
+		}
+
+		if isResourceException(role.Name, "", exceptionRoles) {
 			continue
 		}
 

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -14,7 +14,14 @@ import (
 )
 
 var exceptionServiceAccounts = []ExceptionResource{
-	{ResourceName: "default", Namespace: "*"},
+	{
+		ResourceName: "default",
+		Namespace:    "*",
+	},
+	{
+		ResourceName: "metadata-proxy",
+		Namespace:    "kube-system",
+	},
 }
 
 func getServiceAccountsFromClusterRoleBindings(clientset kubernetes.Interface, namespace string) ([]string, error) {

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -18,6 +18,10 @@ var exceptionServices = []ExceptionResource{
 		ResourceName: "k8s.io-minikube-hostpath",
 		Namespace:    "kube-system",
 	},
+	{
+		ResourceName: "vpa-recommender",
+		Namespace:    "kube-system",
+	},
 }
 
 func ProcessNamespaceServices(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -19,6 +19,14 @@ var exceptionStorageClasses = []ExceptionResource{
 		ResourceName: "standard",
 		Namespace:    "",
 	},
+	{
+		ResourceName: "premium-rwo",
+		Namespace:    "",
+	},
+	{
+		ResourceName: "standard-rwo",
+		Namespace:    "",
+	},
 }
 
 func retrieveUsedStorageClasses(clientset kubernetes.Interface) ([]string, error) {

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -80,18 +80,16 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 			continue
 		}
 
+		if isResourceException(sc.Name, sc.Namespace, exceptionStorageClasses) {
+			continue
+		}
+
 		storageClassNames = append(storageClassNames, sc.Name)
 	}
 
 	usedStorageClasses, err := retrieveUsedStorageClasses(clientset)
 	if err != nil {
 		return nil, err
-	}
-
-	for i, name := range storageClassNames {
-		if isResourceException(name, "", exceptionStorageClasses) {
-			storageClassNames = append(storageClassNames[:i], storageClassNames[i+1:]...)
-		}
 	}
 
 	diff := CalculateResourceDifference(usedStorageClasses, storageClassNames)


### PR DESCRIPTION
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\



Unused Resources in Namespace: gmp-system
+---+---------------+---------------------------+
| # | RESOURCE TYPE |       RESOURCE NAME       |
+---+---------------+---------------------------+
| 1 | ConfigMap     | config-images             |
| 2 | ConfigMap     | webhook-ca                |
| 3 | ReplicaSet    | rule-evaluator-6fd7ddb94c |
+---+---------------+---------------------------+



Unused Resources in Namespace: kube-system
+----+----------------+------------------------------------------------------+
| #  | RESOURCE TYPE  |                    RESOURCE NAME                     |
+----+----------------+------------------------------------------------------+
|  1 | ConfigMap      | cluster-autoscaler-status                            |
|  2 | ConfigMap      | cluster-kubestore                                    |
|  3 | ConfigMap      | clustermetrics                                       |
|  4 | ConfigMap      | extension-apiserver-authentication                   |
|  5 | ConfigMap      | gke-common-webhook-heartbeat                         |
|  6 | ConfigMap      | ingress-uid                                          |
|  7 | ConfigMap      | konnectivity-agent-autoscaler-config                 |
|  8 | ConfigMap      | kube-apiserver-legacy-service-account-token-tracking |
|  9 | ConfigMap      | kube-dns-autoscaler                                  |
| 10 | ConfigMap      | kubedns-config-images                                |
| 11 | Service        | vpa-recommender                                      |
| 12 | ServiceAccount | metadata-proxy                                       |
| 13 | Role           | cloud-provider                                       |
| 14 | Role           | system:controller:glbc                               |
| 15 | ReplicaSet     | metrics-server-v0.6.3-7cb4458849                     |
| 16 | DaemonSet      | fluentbit-gke-256pd                                  |
| 17 | DaemonSet      | fluentbit-gke-max                                    |
| 18 | DaemonSet      | gke-metrics-agent-scaling-10                         |
| 19 | DaemonSet      | gke-metrics-agent-scaling-100                        |
| 20 | DaemonSet      | gke-metrics-agent-scaling-20                         |
| 21 | DaemonSet      | gke-metrics-agent-scaling-200                        |
| 22 | DaemonSet      | gke-metrics-agent-scaling-50                         |
| 23 | DaemonSet      | gke-metrics-agent-scaling-500                        |
| 24 | DaemonSet      | gke-metrics-agent-windows                            |
| 25 | DaemonSet      | kube-proxy                                           |
| 26 | DaemonSet      | metadata-proxy-v0.1                                  |
| 27 | DaemonSet      | nccl-fastsocket-installer                            |
| 28 | DaemonSet      | nvidia-gpu-device-plugin-large-cos                   |
| 29 | DaemonSet      | nvidia-gpu-device-plugin-large-ubuntu                |
| 30 | DaemonSet      | nvidia-gpu-device-plugin-medium-cos                  |
| 31 | DaemonSet      | nvidia-gpu-device-plugin-medium-ubuntu               |
| 32 | DaemonSet      | nvidia-gpu-device-plugin-small-cos                   |
| 33 | DaemonSet      | nvidia-gpu-device-plugin-small-ubuntu                |
| 34 | DaemonSet      | pdcsi-node-windows                                   |
| 35 | DaemonSet      | runsc-metric-server                                  |
| 36 | DaemonSet      | tpu-device-plugin                                    |
+----+----------------+------------------------------------------------------+


Unused Crds: 
+----+---------------+-------------------------------------------------+
| #  | RESOURCE TYPE |                  RESOURCE NAME                  |
+----+---------------+-------------------------------------------------+
|  1 | Crd           | allowlistedv2workloads.auto.gke.io              |
|  2 | Crd           | allowlistedworkloads.auto.gke.io                |
|  3 | Crd           | backendconfigs.cloud.google.com                 |
|  4 | Crd           | capacityrequests.internal.autoscaling.gke.io    |
|  5 | Crd           | clusterpodmonitorings.monitoring.googleapis.com |
|  6 | Crd           | clusterrules.monitoring.googleapis.com          |
|  7 | Crd           | frontendconfigs.networking.gke.io               |
|  8 | Crd           | gkenetworkparamsets.networking.gke.io           |
|  9 | Crd           | globalrules.monitoring.googleapis.com           |
| 10 | Crd           | managedcertificates.networking.gke.io           |
| 11 | Crd           | memberships.hub.gke.io                          |
| 12 | Crd           | networks.networking.gke.io                      |
| 13 | Crd           | podmonitorings.monitoring.googleapis.com        |
| 14 | Crd           | provisioningrequests.autoscaling.x-k8s.io       |
| 15 | Crd           | rules.monitoring.googleapis.com                 |
| 16 | Crd           | serviceattachments.networking.gke.io            |
| 17 | Crd           | servicenetworkendpointgroups.networking.gke.io  |
| 18 | Crd           | updateinfos.nodemanagement.gke.io               |
| 19 | Crd           | volumesnapshotclasses.snapshot.storage.k8s.io   |
| 20 | Crd           | volumesnapshotcontents.snapshot.storage.k8s.io  |
| 21 | Crd           | volumesnapshots.snapshot.storage.k8s.io         |
+----+---------------+-------------------------------------------------+


Unused ClusterRoles: 
+----+---------------+----------------------------------------------------------------------+
| #  | RESOURCE TYPE |                            RESOURCE NAME                             |
+----+---------------+----------------------------------------------------------------------+
|  1 | ClusterRole   | admin                                                                |
|  2 | ClusterRole   | cloud-provider                                                       |
|  3 | ClusterRole   | edit                                                                 |
|  4 | ClusterRole   | system:aggregate-to-admin                                            |
|  5 | ClusterRole   | system:aggregate-to-edit                                             |
|  6 | ClusterRole   | system:certificates.k8s.io:certificatesigningrequests:nodeclient     |
|  7 | ClusterRole   | system:certificates.k8s.io:certificatesigningrequests:selfnodeclient |
|  8 | ClusterRole   | system:certificates.k8s.io:kube-apiserver-client-approver            |
|  9 | ClusterRole   | system:certificates.k8s.io:kube-apiserver-client-kubelet-approver    |
| 10 | ClusterRole   | system:certificates.k8s.io:kubelet-serving-approver                  |
| 11 | ClusterRole   | system:certificates.k8s.io:legacy-unknown-approver                   |
| 12 | ClusterRole   | system:controller:cloud-node-controller                              |
| 13 | ClusterRole   | system:controller:glbc                                               |
| 14 | ClusterRole   | system:heapster                                                      |
| 15 | ClusterRole   | system:kube-aggregator                                               |
| 16 | ClusterRole   | system:kubelet-api-admin                                             |
| 17 | ClusterRole   | system:persistent-volume-provisioner                                 |
+----+---------------+----------------------------------------------------------------------+

Unused StorageClasss: 
+---+---------------+---------------+
| # | RESOURCE TYPE | RESOURCE NAME |
+---+---------------+---------------+
| 1 | StorageClass  | premium-rwo   |
| 2 | StorageClass  | standard      |
| 3 | StorageClass  | standard-rwo  |
+---+---------------+---------------+



