### PR TITLE
ci: skip running go checks when no relevant files were changed

### DIFF
--- a/.github/workflows/merge-request.yml
+++ b/.github/workflows/merge-request.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.go'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Skip triggering CI checks when no `.go` files were changed in pull requests.
For example, this pull request doesn't require any go checks but they still ran: https://github.com/yonahd/kor/pull/251

## PR Checklist

- [x] This PR adds exceptions
- [ ] This PR add new code
- [ ] This PR includes test for any new code

## Github Issue

[XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
