### PR TITLE
feat: allow grouping options for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --delete                       Delete unused resources
   -l, --exclude-labels strings       Selector to filter out, Example: --exclude-labels key1=value1,key2=value2. If --include-labels is set, --exclude-labels will be ignored.
   -e, --exclude-namespaces strings   Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored.
+      --group-by string              Group output by (namespace, resource) (default "namespace")
   -h, --help                         help for kor
       --include-labels string        Selector to filter in, Example: --include-labels key1=value1.(currently supports one label)
   -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored.
@@ -151,7 +152,7 @@ For more information about each subcommand and its available flags, you can use 
 kor [subcommand] --help
 ```
 
-## Supported resources and limitations
+### Supported resources and limitations
 
 | Resource        | What it looks for                                                                                                                                                                                                                 | Known False Positives ⚠️                                                                                                                                              |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -174,7 +175,7 @@ kor [subcommand] --help
 | DaemonSets      | DaemonSets not scheduled on any nodes                                                                                                                                                                                             |
 | StorageClasses  | StorageClasses not used by any PVs/PVCs                                                                                                                                                                                           |
 
-## Deleting Unused resources
+### Deleting Unused resources
 
 If you want to delete resources in an interactive way using Kor you can run:
 
@@ -194,7 +195,7 @@ To delete with no prompt ( ⚠️ use with caution):
 kor configmap --include-namespaces my-namespace --delete --no-interactive
 ```
 
-## Ignore Resources
+### Ignore Resources
 
 The resources labeled with:
 
@@ -204,7 +205,7 @@ kor/used=true
 
 Will be ignored by kor even if they are unused. You can add this label to resources you want to ignore.
 
-## Force clean Resources
+### Force clean Resources
 
 The resources labeled with:
 
@@ -213,6 +214,66 @@ kor/used=false
 ```
 
 Will be cleaned always. This is a good way to mark resources for later cleanup.
+
+### Output Formats
+
+Kor supports three output formats: `table`, `json`, and `yaml`. The default output format is `table`.  
+Additionally, you can use the `--group-by` flag to group the output by `namespace` or `resource`.
+
+#### Group by resource
+
+```sh
+kor all --group-by=resource --output=table
+```
+```
+Unused ConfigMaps:
++---+-----------+---------------+
+| # | NAMESPACE | RESOURCE NAME |
++---+-----------+---------------+
+| 1 | ns1       | cm1           |
+| 2 | ns1       | cm2           |
+| 3 | ns2       | cm3           |
++---+-----------+---------------+
+Unused Deployments:
++---+-----------+---------------+
+| # | NAMESPACE | RESOURCE NAME |
++---+-----------+---------------+
+| 1 | ns1       | deploy1       |
+| 2 | ns2       | deploy2       |
++---+-----------+---------------+
+Unused ReplicaSets:
++---+-----------+--------------------+
+| # | NAMESPACE |   RESOURCE NAME    |
++---+-----------+--------------------+
+| 1 | ns1       | deploy1-654d48b75f |
+| 2 | ns2       | deploy2-79f48888c6 |
++---+-----------+--------------------+
+```
+
+#### Group by namespace
+
+```sh
+kor all --group-by=namespace --output=table
+```
+```
+Unused resources in namespace: "ns1"
++---+---------------+--------------------+
+| # | RESOURCE TYPE |   RESOURCE NAME    |
++---+---------------+--------------------+
+| 1 | ConfigMap     | cm1                |
+| 2 | ConfigMap     | cm2                |
+| 3 | ReplicaSet    | deploy1-654d48b75f |
+| 4 | Deployment    | deploy1            |
++---+---------------+--------------------+
+Unused resources in namespace: "ns2"
++---+---------------+--------------------+
+| # | RESOURCE TYPE |   RESOURCE NAME    |
++---+---------------+--------------------+
+| 1 | ReplicaSet    | deploy2-79f48888c6 |
+| 2 | ConfigMap     | cm3                |
+| 3 | Deployment    | deploy2            |
++---+---------------+--------------------+
+```
 
 ## In Cluster Usage
 

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -59,6 +59,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&opts.DeleteFlag, "delete", false, "Delete unused resources")
 	rootCmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Do not prompt for confirmation when deleting resources. Be careful using this flag!")
 	rootCmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output (print empty namespaces)")
+	rootCmd.PersistentFlags().StringVar(&opts.GroupBy, "group-by", "namespace", "Group output by (namespace, resource)")
 	addFilterOptionsFlag(rootCmd, filterOptions)
 }
 

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -28,16 +28,22 @@ func getUnusedCMs(clientset kubernetes.Interface, namespace string, filterOpts *
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "configmaps", namespace, err)
 	}
-	namespaceCMDiff := ResourceDiff{"ConfigMap", cmDiff}
+	namespaceCMDiff := ResourceDiff{
+		"ConfigMap",
+		cmDiff,
+	}
 	return namespaceCMDiff
 }
 
 func getUnusedSVCs(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	svcDiff, err := ProcessNamespaceServices(clientset, namespace, filterOpts)
+	svcDiff, err := processNamespaceServices(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "services", namespace, err)
 	}
-	namespaceSVCDiff := ResourceDiff{"Service", svcDiff}
+	namespaceSVCDiff := ResourceDiff{
+		"Service",
+		svcDiff,
+	}
 	return namespaceSVCDiff
 }
 
@@ -46,7 +52,10 @@ func getUnusedSecrets(clientset kubernetes.Interface, namespace string, filterOp
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "secrets", namespace, err)
 	}
-	namespaceSecretDiff := ResourceDiff{"Secret", secretDiff}
+	namespaceSecretDiff := ResourceDiff{
+		"Secret",
+		secretDiff,
+	}
 	return namespaceSecretDiff
 }
 
@@ -55,25 +64,34 @@ func getUnusedServiceAccounts(clientset kubernetes.Interface, namespace string, 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "serviceaccounts", namespace, err)
 	}
-	namespaceSADiff := ResourceDiff{"ServiceAccount", saDiff}
+	namespaceSADiff := ResourceDiff{
+		"ServiceAccount",
+		saDiff,
+	}
 	return namespaceSADiff
 }
 
 func getUnusedDeployments(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	deployDiff, err := ProcessNamespaceDeployments(clientset, namespace, filterOpts)
+	deployDiff, err := processNamespaceDeployments(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "deployments", namespace, err)
 	}
-	namespaceSADiff := ResourceDiff{"Deployment", deployDiff}
+	namespaceSADiff := ResourceDiff{
+		"Deployment",
+		deployDiff,
+	}
 	return namespaceSADiff
 }
 
 func getUnusedStatefulSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	stsDiff, err := ProcessNamespaceStatefulSets(clientset, namespace, filterOpts)
+	stsDiff, err := processNamespaceStatefulSets(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "statefulSets", namespace, err)
 	}
-	namespaceSADiff := ResourceDiff{"StatefulSet", stsDiff}
+	namespaceSADiff := ResourceDiff{
+		"StatefulSet",
+		stsDiff,
+	}
 	return namespaceSADiff
 }
 
@@ -82,7 +100,10 @@ func getUnusedRoles(clientset kubernetes.Interface, namespace string, filterOpts
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "roles", namespace, err)
 	}
-	namespaceSADiff := ResourceDiff{"Role", roleDiff}
+	namespaceSADiff := ResourceDiff{
+		"Role",
+		roleDiff,
+	}
 	return namespaceSADiff
 }
 
@@ -91,7 +112,10 @@ func getUnusedClusterRoles(clientset kubernetes.Interface, filterOpts *filters.O
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s: %v\n", "clusterRoles", err)
 	}
-	aDiff := ResourceDiff{"ClusterRole", clusterRoleDiff}
+	aDiff := ResourceDiff{
+		"ClusterRole",
+		clusterRoleDiff,
+	}
 	return aDiff
 }
 
@@ -100,7 +124,10 @@ func getUnusedHpas(clientset kubernetes.Interface, namespace string, filterOpts 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "hpas", namespace, err)
 	}
-	namespaceHpaDiff := ResourceDiff{"Hpa", hpaDiff}
+	namespaceHpaDiff := ResourceDiff{
+		"Hpa",
+		hpaDiff,
+	}
 	return namespaceHpaDiff
 }
 
@@ -109,7 +136,10 @@ func getUnusedPvcs(clientset kubernetes.Interface, namespace string, filterOpts 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "pvcs", namespace, err)
 	}
-	namespacePvcDiff := ResourceDiff{"Pvc", pvcDiff}
+	namespacePvcDiff := ResourceDiff{
+		"Pvc",
+		pvcDiff,
+	}
 	return namespacePvcDiff
 }
 
@@ -118,7 +148,10 @@ func getUnusedIngresses(clientset kubernetes.Interface, namespace string, filter
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "ingresses", namespace, err)
 	}
-	namespaceIngressDiff := ResourceDiff{"Ingress", ingressDiff}
+	namespaceIngressDiff := ResourceDiff{
+		"Ingress",
+		ingressDiff,
+	}
 	return namespaceIngressDiff
 }
 
@@ -127,7 +160,10 @@ func getUnusedPdbs(clientset kubernetes.Interface, namespace string, filterOpts 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "pdbs", namespace, err)
 	}
-	namespacePdbDiff := ResourceDiff{"Pdb", pdbDiff}
+	namespacePdbDiff := ResourceDiff{
+		"Pdb",
+		pdbDiff,
+	}
 	return namespacePdbDiff
 }
 
@@ -136,7 +172,10 @@ func getUnusedCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s: %v\n", "Crds", err)
 	}
-	allCrdDiff := ResourceDiff{"Crd", crdDiff}
+	allCrdDiff := ResourceDiff{
+		"Crd",
+		crdDiff,
+	}
 	return allCrdDiff
 }
 
@@ -145,43 +184,58 @@ func getUnusedPvs(clientset kubernetes.Interface, filterOpts *filters.Options) R
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s: %v\n", "Pvs", err)
 	}
-	allPvDiff := ResourceDiff{"Pv", pvDiff}
+	allPvDiff := ResourceDiff{
+		"Pv",
+		pvDiff,
+	}
 	return allPvDiff
 }
 
 func getUnusedPods(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	podDiff, err := ProcessNamespacePods(clientset, namespace, filterOpts)
+	podDiff, err := processNamespacePods(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "pods", namespace, err)
 	}
-	namespacePodDiff := ResourceDiff{"Pod", podDiff}
+	namespacePodDiff := ResourceDiff{
+		"Pod",
+		podDiff,
+	}
 	return namespacePodDiff
 }
 
 func getUnusedJobs(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	jobDiff, err := ProcessNamespaceJobs(clientset, namespace, filterOpts)
+	jobDiff, err := processNamespaceJobs(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "jobs", namespace, err)
 	}
-	namespaceJobDiff := ResourceDiff{"Job", jobDiff}
+	namespaceJobDiff := ResourceDiff{
+		"Job",
+		jobDiff,
+	}
 	return namespaceJobDiff
 }
 
 func getUnusedReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	replicaSetDiff, err := ProcessNamespaceReplicaSets(clientset, namespace, filterOpts)
+	replicaSetDiff, err := processNamespaceReplicaSets(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "jobs", namespace, err)
 	}
-	namespaceRSDiff := ResourceDiff{"ReplicaSet", replicaSetDiff}
+	namespaceRSDiff := ResourceDiff{
+		"ReplicaSet",
+		replicaSetDiff,
+	}
 	return namespaceRSDiff
 }
 
 func getUnusedDaemonSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	dsDiff, err := ProcessNamespaceDaemonSets(clientset, namespace, filterOpts)
+	dsDiff, err := processNamespaceDaemonSets(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "DaemonSets", namespace, err)
 	}
-	namespaceSADiff := ResourceDiff{"DaemonSet", dsDiff}
+	namespaceSADiff := ResourceDiff{
+		"DaemonSet",
+		dsDiff,
+	}
 	return namespaceSADiff
 }
 
@@ -190,64 +244,63 @@ func getUnusedStorageClasses(clientset kubernetes.Interface, filterOpts *filters
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s: %v\n", "StorageClasses", err)
 	}
-	allScDiff := ResourceDiff{"StorageClass", scDiff}
+	allScDiff := ResourceDiff{
+		"StorageClass",
+		scDiff,
+	}
 	return allScDiff
 }
 
 func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		var allDiffs []ResourceDiff
-		namespaceCMDiff := getUnusedCMs(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceCMDiff)
-		namespaceSVCDiff := getUnusedSVCs(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceSVCDiff)
-		namespaceSecretDiff := getUnusedSecrets(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceSecretDiff)
-		namespaceSADiff := getUnusedServiceAccounts(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceSADiff)
-		namespaceDeploymentDiff := getUnusedDeployments(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceDeploymentDiff)
-		namespaceStatefulsetDiff := getUnusedStatefulSets(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceStatefulsetDiff)
-		namespaceRoleDiff := getUnusedRoles(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceRoleDiff)
-		namespaceHpaDiff := getUnusedHpas(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceHpaDiff)
-		namespacePvcDiff := getUnusedPvcs(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespacePvcDiff)
-		namespacePodDiff := getUnusedPods(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespacePodDiff)
-		namespaceIngressDiff := getUnusedIngresses(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceIngressDiff)
-		namespacePdbDiff := getUnusedPdbs(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespacePdbDiff)
-		namespaceJobDiff := getUnusedJobs(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceJobDiff)
-		namespaceRSDiff := getUnusedReplicaSets(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceRSDiff)
-		namespaceDaemonsetDiff := getUnusedDaemonSets(clientset, namespace, filterOpts)
-		allDiffs = append(allDiffs, namespaceDaemonsetDiff)
-
-		output := FormatOutputAll(namespace, allDiffs, opts)
-
-		outputBuffer.WriteString(output)
-		outputBuffer.WriteString("\n")
-
-		resourceMap := make(map[string][]string)
-		for _, diff := range allDiffs {
-			resourceMap[diff.resourceType] = diff.diff
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["ConfigMap"] = getUnusedCMs(clientset, namespace, filterOpts).diff
+			resources[namespace]["Service"] = getUnusedSVCs(clientset, namespace, filterOpts).diff
+			resources[namespace]["Secret"] = getUnusedSecrets(clientset, namespace, filterOpts).diff
+			resources[namespace]["ServiceAccount"] = getUnusedServiceAccounts(clientset, namespace, filterOpts).diff
+			resources[namespace]["Deployment"] = getUnusedDeployments(clientset, namespace, filterOpts).diff
+			resources[namespace]["StatefulSet"] = getUnusedStatefulSets(clientset, namespace, filterOpts).diff
+			resources[namespace]["Role"] = getUnusedRoles(clientset, namespace, filterOpts).diff
+			resources[namespace]["Hpa"] = getUnusedHpas(clientset, namespace, filterOpts).diff
+			resources[namespace]["Pvc"] = getUnusedPvcs(clientset, namespace, filterOpts).diff
+			resources[namespace]["Pod"] = getUnusedPods(clientset, namespace, filterOpts).diff
+			resources[namespace]["Ingress"] = getUnusedIngresses(clientset, namespace, filterOpts).diff
+			resources[namespace]["Pdb"] = getUnusedPdbs(clientset, namespace, filterOpts).diff
+			resources[namespace]["Job"] = getUnusedJobs(clientset, namespace, filterOpts).diff
+			resources[namespace]["ReplicaSet"] = getUnusedReplicaSets(clientset, namespace, filterOpts).diff
+			resources[namespace]["DaemonSet"] = getUnusedDaemonSets(clientset, namespace, filterOpts).diff
+		case "resource":
+			appendResources(resources, "ConfigMap", namespace, getUnusedCMs(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Service", namespace, getUnusedSVCs(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Secret", namespace, getUnusedSecrets(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "ServiceAccount", namespace, getUnusedServiceAccounts(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Deployment", namespace, getUnusedDeployments(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "StatefulSet", namespace, getUnusedStatefulSets(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Role", namespace, getUnusedRoles(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Hpa", namespace, getUnusedHpas(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Pvc", namespace, getUnusedPvcs(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Pod", namespace, getUnusedPods(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Ingress", namespace, getUnusedIngresses(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Pdb", namespace, getUnusedPdbs(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "Job", namespace, getUnusedJobs(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "ReplicaSet", namespace, getUnusedReplicaSets(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "DaemonSet", namespace, getUnusedDaemonSets(clientset, namespace, filterOpts).diff)
 		}
-		response[namespace] = resourceMap
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedAllNamespaced, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
@@ -259,44 +312,31 @@ func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.In
 }
 
 func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
+	resources := make(map[string]map[string][]string)
+	switch opts.GroupBy {
+	case "namespace":
+		resources[""] = make(map[string][]string)
+		resources[""]["Crd"] = getUnusedCrds(apiExtClient, dynamicClient, filterOpts).diff
+		resources[""]["Pv"] = getUnusedPvs(clientset, filterOpts).diff
+		resources[""]["ClusterRole"] = getUnusedClusterRoles(clientset, filterOpts).diff
+		resources[""]["StorageClass"] = getUnusedStorageClasses(clientset, filterOpts).diff
+	case "resource":
+		appendResources(resources, "Crd", "", getUnusedCrds(apiExtClient, dynamicClient, filterOpts).diff)
+		appendResources(resources, "Pv", "", getUnusedPvs(clientset, filterOpts).diff)
+		appendResources(resources, "ClusterRole", "", getUnusedClusterRoles(clientset, filterOpts).diff)
+		appendResources(resources, "StorageClass", "", getUnusedStorageClasses(clientset, filterOpts).diff)
+	}
+
 	var outputBuffer bytes.Buffer
-	response := make(map[string]map[string][]string)
-
-	var allDiffs []ResourceDiff
-	noNamespaceResourceMap := make(map[string][]string)
-	crdDiff := getUnusedCrds(apiExtClient, dynamicClient, filterOpts)
-	crdOutput := FormatOutputAll("", []ResourceDiff{crdDiff}, opts)
-	outputBuffer.WriteString(crdOutput)
-	outputBuffer.WriteString("\n")
-	noNamespaceResourceMap[crdDiff.resourceType] = crdDiff.diff
-
-	pvDiff := getUnusedPvs(clientset, filterOpts)
-	pvOutput := FormatOutputAll("", []ResourceDiff{pvDiff}, opts)
-	outputBuffer.WriteString(pvOutput)
-	outputBuffer.WriteString("\n")
-	noNamespaceResourceMap[pvDiff.resourceType] = pvDiff.diff
-
-	clusterRoleDiff := getUnusedClusterRoles(clientset, filterOpts)
-	clusterRoleOutput := FormatOutputAll("", []ResourceDiff{clusterRoleDiff}, opts)
-	outputBuffer.WriteString(clusterRoleOutput)
-	outputBuffer.WriteString("\n")
-	noNamespaceResourceMap[clusterRoleDiff.resourceType] = clusterRoleDiff.diff
-
-	storageClassDiff := getUnusedStorageClasses(clientset, filterOpts)
-	storageClassOutput := FormatOutputAll("", []ResourceDiff{storageClassDiff}, opts)
-	outputBuffer.WriteString(storageClassOutput)
-	outputBuffer.WriteString("\n")
-	noNamespaceResourceMap[storageClassDiff.resourceType] = storageClassDiff.diff
-
-	output := FormatOutputAll("", allDiffs, opts)
-
-	outputBuffer.WriteString(output)
-	outputBuffer.WriteString("\n")
-	response[""] = noNamespaceResourceMap
-
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedAllNonNamespaced, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/clusterroles_test.go
+++ b/pkg/kor/clusterroles_test.go
@@ -95,7 +95,11 @@ func TestRetrieveUsedClusterRoles(t *testing.T) {
 		t.Errorf("Expected 3 used cluster role, got %d", len(usedClusterRoles))
 	}
 
-	expectedRoles := []string{"test-clusterRole2", "test-clusterRole3", "test-clusterRole6"}
+	expectedRoles := []string{
+		"test-clusterRole2",
+		"test-clusterRole3",
+		"test-clusterRole6",
+	}
 	sort.Strings(usedClusterRoles)
 	t.Log(usedClusterRoles)
 	if !reflect.DeepEqual(usedClusterRoles, expectedRoles) {
@@ -140,6 +144,7 @@ func TestGetUnusedClusterRolesStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedClusterRoles(&filters.Options{}, clientset, "json", opts)
@@ -149,7 +154,10 @@ func TestGetUnusedClusterRolesStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		"": {
-			"ClusterRoles": {"test-clusterRole1", "test-clusterRole5"},
+			"ClusterRole": {
+				"test-clusterRole1",
+				"test-clusterRole5",
+			},
 		},
 	}
 

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -150,35 +150,37 @@ func processNamespaceCM(clientset kubernetes.Interface, namespace string, filter
 }
 
 func GetUnusedConfigmaps(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	response := make(map[string]map[string][]string)
-
+	resources := make(map[string]map[string][]string)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceCM(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["ConfigMap"] = diff
+		case "resource":
+			appendResources(resources, "ConfigMap", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "ConfigMap", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete ConfigMap %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Configmaps", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["ConfigMap"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedCMs, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/configmaps_test.go
+++ b/pkg/kor/configmaps_test.go
@@ -58,14 +58,20 @@ func createTestConfigmaps(t *testing.T) *fake.Clientset {
 	}
 
 	pod1 := CreateTestPod(testNamespace, "pod-1", "", []corev1.Volume{
-		{Name: "vol-1", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configmap1.ObjectMeta.Name}}}},
+		{
+			Name:         "vol-1",
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configmap1.ObjectMeta.Name}}},
+		},
 	}, AppLabels)
 
 	pod2 := CreateTestPod(testNamespace, "pod-2", "", nil, AppLabels)
 	pod2.Spec.Containers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
-				{Name: "ENV_VAR_1", ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: configmap1.ObjectMeta.Name}}}},
+				{
+					Name:      "ENV_VAR_1",
+					ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: configmap1.ObjectMeta.Name}}},
+				},
 			},
 		},
 	}
@@ -83,7 +89,10 @@ func createTestConfigmaps(t *testing.T) *fake.Clientset {
 	pod4.Spec.InitContainers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
-				{Name: "INIT_ENV_VAR_1", ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: configmap2.ObjectMeta.Name}}}},
+				{
+					Name:      "INIT_ENV_VAR_1",
+					ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: configmap2.ObjectMeta.Name}}},
+				},
 			},
 		},
 	}
@@ -120,7 +129,11 @@ func TestRetrieveConfigMapNames(t *testing.T) {
 		t.Fatalf("Error retrieving configmap names: %v", err)
 	}
 
-	expectedConfigMapNames := []string{"configmap-1", "configmap-2", "configmap-3"}
+	expectedConfigMapNames := []string{
+		"configmap-1",
+		"configmap-2",
+		"configmap-3",
+	}
 	if !equalSlices(configMapNames, expectedConfigMapNames) {
 		t.Errorf("Expected configmap names %v, got %v", expectedConfigMapNames, configMapNames)
 	}
@@ -134,7 +147,10 @@ func TestProcessNamespaceCM(t *testing.T) {
 		t.Fatalf("Error processing namespace CM: %v", err)
 	}
 
-	unusedConfigmaps := []string{"configmap-3", "configmap-5"}
+	unusedConfigmaps := []string{
+		"configmap-3",
+		"configmap-5",
+	}
 	if !equalSlices(diff, unusedConfigmaps) {
 		t.Errorf("Expected diff %v, got %v", unusedConfigmaps, diff)
 	}
@@ -149,7 +165,10 @@ func TestRetrieveUsedCM(t *testing.T) {
 		t.Fatalf("Error retrieving used ConfigMaps: %v", err)
 	}
 
-	expectedVolumesCM := []string{"configmap-1", "kube-root-ca.crt"}
+	expectedVolumesCM := []string{
+		"configmap-1",
+		"kube-root-ca.crt",
+	}
 	if !equalSlices(volumesCM, expectedVolumesCM) {
 		t.Errorf("Expected volume configmaps %v, got %v", expectedVolumesCM, volumesCM)
 	}
@@ -185,6 +204,7 @@ func TestGetUnusedConfigmapsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedConfigmaps(&filters.Options{}, clientset, "json", opts)
@@ -194,7 +214,10 @@ func TestGetUnusedConfigmapsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"ConfigMap": {"configmap-3", "configmap-5"},
+			"ConfigMap": {
+				"configmap-3",
+				"configmap-5",
+			},
 		},
 	}
 

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -17,7 +17,7 @@ import (
 //go:embed exceptions/daemonsets/daemonsets.json
 var daemonsetsConfig []byte
 
-func ProcessNamespaceDaemonSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceDaemonSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	daemonSetsList, err := clientset.AppsV1().DaemonSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -53,35 +53,37 @@ func ProcessNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 }
 
 func GetUnusedDaemonSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespaceDaemonSets(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceDaemonSets(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
+		}
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["DaemonSet"] = diff
+		case "resource":
+			appendResources(resources, "DaemonSet", namespace, diff)
 		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "DaemonSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete DaemonSet %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "DaemonSets", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["DaemonSets"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedDaemonSets, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/daemonsets_test.go
+++ b/pkg/kor/daemonsets_test.go
@@ -65,7 +65,7 @@ func createTestDaemonSets(t *testing.T) *fake.Clientset {
 func TestProcessNamespaceDaemonSets(t *testing.T) {
 	clientset := createTestDaemonSets(t)
 
-	daemonSetsWithoutReplicas, err := ProcessNamespaceDaemonSets(clientset, testNamespace, &filters.Options{})
+	daemonSetsWithoutReplicas, err := processNamespaceDaemonSets(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -88,6 +88,7 @@ func TestGetUnusedDaemonSetsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedDaemonSets(&filters.Options{}, clientset, "json", opts)
@@ -97,7 +98,10 @@ func TestGetUnusedDaemonSetsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"DaemonSets": {"test-ds1", "test-ds4"},
+			"DaemonSet": {
+				"test-ds1",
+				"test-ds4",
+			},
 		},
 	}
 

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-func ProcessNamespaceDeployments(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceDeployments(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	deploymentsList, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -40,35 +40,37 @@ func ProcessNamespaceDeployments(clientset kubernetes.Interface, namespace strin
 }
 
 func GetUnusedDeployments(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	response := make(map[string]map[string][]string)
-
+	resources := make(map[string]map[string][]string)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
-		diff, err := ProcessNamespaceDeployments(clientset, namespace, filterOpts)
+		diff, err := processNamespaceDeployments(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Deployment"] = diff
+		case "resource":
+			appendResources(resources, "Deployment", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Deployment", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Deployment %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Deployments", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Deployments"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedDeployments, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/deployments_test.go
+++ b/pkg/kor/deployments_test.go
@@ -57,7 +57,7 @@ func createTestDeployments(t *testing.T) *fake.Clientset {
 func TestProcessNamespaceDeployments(t *testing.T) {
 	clientset := createTestDeployments(t)
 
-	deploymentsWithoutReplicas, err := ProcessNamespaceDeployments(clientset, testNamespace, &filters.Options{})
+	deploymentsWithoutReplicas, err := processNamespaceDeployments(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -80,6 +80,7 @@ func TestGetUnusedDeploymentsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedDeployments(&filters.Options{}, clientset, "json", opts)
@@ -89,7 +90,10 @@ func TestGetUnusedDeploymentsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Deployments": {"test-deployment1", "test-deployment4"},
+			"Deployment": {
+				"test-deployment1",
+				"test-deployment4",
+			},
 		},
 	}
 

--- a/pkg/kor/finalizers.go
+++ b/pkg/kor/finalizers.go
@@ -97,7 +97,7 @@ func GetUnusedfinalizers(filterOpts *filters.Options, clientset kubernetes.Inter
 				allDiffs[gvr.Resource] = resourceDiff
 			}
 
-			output := FormatOutputFromMap(namespace, allDiffs, opts)
+			output := formatOutputForNamespace(namespace, allDiffs, opts)
 			outputBuffer.WriteString(output)
 			outputBuffer.WriteString("\n")
 

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -81,36 +81,37 @@ func processNamespaceHpas(clientset kubernetes.Interface, namespace string, filt
 }
 
 func GetUnusedHpas(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceHpas(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Hpa"] = diff
+		case "resource":
+			appendResources(resources, "Hpa", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "HPA", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete HPA %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "HPAs", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Hpa"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedHpas, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/hpas_test.go
+++ b/pkg/kor/hpas_test.go
@@ -89,6 +89,7 @@ func TestGetUnusedHpasStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedHpas(&filters.Options{}, clientset, "json", opts)
@@ -98,7 +99,10 @@ func TestGetUnusedHpasStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Hpa": {"test-hpa2", "test-hpa4"},
+			"Hpa": {
+				"test-hpa2",
+				"test-hpa4",
+			},
 		},
 	}
 

--- a/pkg/kor/ingresses_test.go
+++ b/pkg/kor/ingresses_test.go
@@ -96,6 +96,7 @@ func TestGetUnusedIngressesStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedIngresses(&filters.Options{}, clientset, "json", opts)
@@ -105,7 +106,10 @@ func TestGetUnusedIngressesStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Ingresses": {"test-ingress-2", "test-ingress-4"},
+			"Ingress": {
+				"test-ingress-2",
+				"test-ingress-4",
+			},
 		},
 	}
 

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-func ProcessNamespaceJobs(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	jobsList, err := clientset.BatchV1().Jobs(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -36,36 +36,37 @@ func ProcessNamespaceJobs(clientset kubernetes.Interface, namespace string, filt
 }
 
 func GetUnusedJobs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespaceJobs(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceJobs(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Job"] = diff
+		case "resource":
+			appendResources(resources, "Job", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Job", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Job %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Job", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Jobs"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedJobs, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/jobs_test.go
+++ b/pkg/kor/jobs_test.go
@@ -77,7 +77,7 @@ func createTestJobs(t *testing.T) *fake.Clientset {
 func TestProcessNamespaceJobs(t *testing.T) {
 	clientset := createTestJobs(t)
 
-	completedJobs, err := ProcessNamespaceJobs(clientset, testNamespace, &filters.Options{})
+	completedJobs, err := processNamespaceJobs(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -100,6 +100,7 @@ func TestGetUnusedJobsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedJobs(&filters.Options{}, clientset, "json", opts)
@@ -109,7 +110,10 @@ func TestGetUnusedJobsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Jobs": {"test-job2", "test-job4"},
+			"Job": {
+				"test-job2",
+				"test-job4",
+			},
 		},
 	}
 

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -56,36 +56,37 @@ func processNamespacePdbs(clientset kubernetes.Interface, namespace string, filt
 }
 
 func GetUnusedPdbs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespacePdbs(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Pdb"] = diff
+		case "resource":
+			appendResources(resources, "Pdb", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "PDB", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete PDB %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "PDBs", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Pdb"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedPdbs, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -99,6 +99,7 @@ func TestGetUnusedPdbsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedPdbs(&filters.Options{}, clientset, "json", opts)
@@ -108,7 +109,10 @@ func TestGetUnusedPdbsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Pdb": {"test-pdb3", "test-pdb5"},
+			"Pdb": {
+				"test-pdb3",
+				"test-pdb5",
+			},
 		},
 	}
 

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-func ProcessNamespacePods(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespacePods(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	podsList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -42,36 +42,37 @@ func ProcessNamespacePods(clientset kubernetes.Interface, namespace string, filt
 }
 
 func GetUnusedPods(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespacePods(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespacePods(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Pod"] = diff
+		case "resource":
+			appendResources(resources, "Pod", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Pod", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Pod %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Pods", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Pods"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedPods, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/pods_test.go
+++ b/pkg/kor/pods_test.go
@@ -69,7 +69,14 @@ func createTestPods(t *testing.T) *fake.Clientset {
 		Message: "",
 	}
 
-	pods := []*corev1.Pod{pod1, pod2, pod3, pod4, pod5, pod6}
+	pods := []*corev1.Pod{
+		pod1,
+		pod2,
+		pod3,
+		pod4,
+		pod5,
+		pod6,
+	}
 
 	// Add test pods to the clientset
 	for _, pod := range pods {
@@ -84,12 +91,15 @@ func createTestPods(t *testing.T) *fake.Clientset {
 
 func TestProcessNamespacePods(t *testing.T) {
 	clientset := createTestPods(t)
-	evictedPods, err := ProcessNamespacePods(clientset, testNamespace, &filters.Options{})
+	evictedPods, err := processNamespacePods(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	expectedEvictedPods := []string{"pod-2", "pod-6"}
+	expectedEvictedPods := []string{
+		"pod-2",
+		"pod-6",
+	}
 
 	if len(evictedPods) != len(expectedEvictedPods) {
 		t.Errorf("Expected %d evicted pods, got %d", len(expectedEvictedPods), len(evictedPods))
@@ -111,6 +121,7 @@ func TestGetUnusedPodsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedPods(&filters.Options{}, clientset, "json", opts)
@@ -120,7 +131,10 @@ func TestGetUnusedPodsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Pods": {"pod-2", "pod-6"},
+			"Pod": {
+				"pod-2",
+				"pod-6",
+			},
 		},
 	}
 

--- a/pkg/kor/pv_test.go
+++ b/pkg/kor/pv_test.go
@@ -67,6 +67,7 @@ func TestGetUnusedPvs(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedPvs(&filters.Options{}, clientset, "json", opts)
@@ -76,7 +77,10 @@ func TestGetUnusedPvs(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		"": {
-			"Pv": {"test-pv2", "test-pv4"},
+			"Pv": {
+				"test-pv2",
+				"test-pv4",
+			},
 		},
 	}
 

--- a/pkg/kor/pvc_test.go
+++ b/pkg/kor/pvc_test.go
@@ -105,6 +105,7 @@ func TestGetUnusedPvcsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedPvcs(&filters.Options{}, clientset, "json", opts)
@@ -114,7 +115,10 @@ func TestGetUnusedPvcsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Pvc": {"test-pvc2", "test-pvc4"},
+			"Pvc": {
+				"test-pvc2",
+				"test-pvc4",
+			},
 		},
 	}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-func ProcessNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	replicaSetList, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -36,36 +36,37 @@ func ProcessNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 }
 
 func GetUnusedReplicaSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespaceReplicaSets(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceReplicaSets(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["ReplicaSet"] = diff
+		case "resource":
+			appendResources(resources, "ReplicaSet", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "ReplicaSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete ReplicaSet %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "ReplicaSets", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["ReplicaSets"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedReplicaSets, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -63,6 +63,7 @@ func TestProcessNamespaceReplicaSets(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedReplicaSets(&filters.Options{}, clientset, "json", opts)
@@ -72,7 +73,7 @@ func TestProcessNamespaceReplicaSets(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"ReplicaSets": {"test-replicaSet2"},
+			"ReplicaSet": {"test-replicaSet2"},
 		},
 	}
 

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -92,36 +92,37 @@ func processNamespaceRoles(clientset kubernetes.Interface, namespace string, fil
 }
 
 func GetUnusedRoles(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceRoles(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Role"] = diff
+		case "resource":
+			appendResources(resources, "Role", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Role", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Role %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Roles", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Roles"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedRoles, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/roles_test.go
+++ b/pkg/kor/roles_test.go
@@ -115,6 +115,7 @@ func TestGetUnusedRolesStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedRoles(&filters.Options{}, clientset, "json", opts)
@@ -124,7 +125,10 @@ func TestGetUnusedRolesStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Roles": {"test-role2", "test-role4"},
+			"Role": {
+				"test-role2",
+				"test-role4",
+			},
 		},
 	}
 

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -175,36 +175,37 @@ func processNamespaceSecret(clientset kubernetes.Interface, namespace string, fi
 }
 
 func GetUnusedSecrets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceSecret(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Secret"] = diff
+		case "resource":
+			appendResources(resources, "Secret", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Secret", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Secret %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Secrets", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Secrets"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedSecrets, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/secrets_test.go
+++ b/pkg/kor/secrets_test.go
@@ -34,18 +34,27 @@ func createTestSecrets(t *testing.T) *fake.Clientset {
 	secret5 := CreateTestSecret(testNamespace, "test-secret5", UnusedLabels)
 
 	pod1 := CreateTestPod(testNamespace, "pod-1", "", []corev1.Volume{
-		{Name: "vol-1", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret1"}}},
+		{
+			Name:         "vol-1",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret1"}},
+		},
 	}, AppLabels)
 
 	pod2 := CreateTestPod(testNamespace, "pod-2", "", []corev1.Volume{
-		{Name: "vol-2", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret2"}}},
+		{
+			Name:         "vol-2",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-secret2"}},
+		},
 	}, AppLabels)
 
 	pod3 := CreateTestPod(testNamespace, "pod-3", "", nil, AppLabels)
 	pod3.Spec.Containers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
-				{Name: "ENV_VAR_1", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secret1.ObjectMeta.Name}}}},
+				{
+					Name:      "ENV_VAR_1",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secret1.ObjectMeta.Name}}},
+				},
 			},
 		},
 	}
@@ -63,7 +72,10 @@ func createTestSecrets(t *testing.T) *fake.Clientset {
 	pod5.Spec.InitContainers = []corev1.Container{
 		{
 			Env: []corev1.EnvVar{
-				{Name: "INIT_ENV_VAR_1", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secret1.ObjectMeta.Name}}}},
+				{
+					Name:      "INIT_ENV_VAR_1",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: secret1.ObjectMeta.Name}}},
+				},
 			},
 		},
 	}
@@ -178,7 +190,10 @@ func TestRetrieveUsedSecret(t *testing.T) {
 		t.Fatalf("Error retrieving used secrets: %v", err)
 	}
 
-	expectedVolumeSecrets := []string{"test-secret1", "test-secret2"}
+	expectedVolumeSecrets := []string{
+		"test-secret1",
+		"test-secret2",
+	}
 	if !equalSlices(volumeSecrets, expectedVolumeSecrets) {
 		t.Errorf("Expected volume secrets %v, got %v", expectedVolumeSecrets, volumeSecrets)
 	}
@@ -198,7 +213,10 @@ func TestRetrieveUsedSecret(t *testing.T) {
 		t.Errorf("Expected initContainer env secrets %v, got %v", expectedInitContainerEnvSecrets, initContainerEnvSecrets)
 	}
 
-	expectedPullSecrets := []string{"test-secret1", "test-secret2"}
+	expectedPullSecrets := []string{
+		"test-secret1",
+		"test-secret2",
+	}
 	if !equalSlices(pullSecrets, expectedPullSecrets) {
 		t.Errorf("Expected pull secrets %v, got %v", expectedPullSecrets, pullSecrets)
 	}
@@ -228,7 +246,10 @@ func TestRetrieveSecretNames(t *testing.T) {
 		t.Fatalf("Error retrieving secret names: %v", err)
 	}
 
-	expectedSecretNames := []string{"secret-1", "secret-2"}
+	expectedSecretNames := []string{
+		"secret-1",
+		"secret-2",
+	}
 	if !equalSlices(secretNames, expectedSecretNames) {
 		t.Errorf("Expected secret names %v, got %v", expectedSecretNames, secretNames)
 	}
@@ -261,6 +282,7 @@ func TestGetUnusedSecretsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedSecrets(&filters.Options{}, clientset, "json", opts)
@@ -270,7 +292,10 @@ func TestGetUnusedSecretsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Secrets": {"test-secret3", "test-secret5"},
+			"Secret": {
+				"test-secret3",
+				"test-secret5",
+			},
 		},
 	}
 

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -155,37 +155,37 @@ func processNamespaceSA(clientset kubernetes.Interface, namespace string, filter
 }
 
 func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceSA(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["ServiceAccount"] = diff
+		case "resource":
+			appendResources(resources, "ServiceAccount", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Serviceaccount %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Serviceaccounts", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["ServiceAccounts"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedServiceAccounts, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/serviceaccounts_test.go
+++ b/pkg/kor/serviceaccounts_test.go
@@ -190,6 +190,7 @@ func TestGetUnusedServiceAccountsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedServiceAccounts(&filters.Options{}, clientset, "json", opts)
@@ -199,7 +200,10 @@ func TestGetUnusedServiceAccountsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"ServiceAccounts": {"test-sa2", "test-sa4"},
+			"ServiceAccount": {
+				"test-sa2",
+				"test-sa4",
+			},
 		},
 	}
 

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -17,7 +17,7 @@ import (
 //go:embed exceptions/services/services.json
 var servicesConfig []byte
 
-func ProcessNamespaceServices(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceServices(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	endpointsList, err := clientset.CoreV1().Endpoints(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -52,37 +52,37 @@ func ProcessNamespaceServices(clientset kubernetes.Interface, namespace string, 
 }
 
 func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespaceServices(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceServices(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["Service"] = diff
+		case "resource":
+			appendResources(resources, "Service", namespace, diff)
+		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "Service", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Service %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Services", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Services"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedServices, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/services_test.go
+++ b/pkg/kor/services_test.go
@@ -57,7 +57,7 @@ func createTestServices(t *testing.T) *fake.Clientset {
 func TestGetEndpointsWithoutSubsets(t *testing.T) {
 	clientset := createTestServices(t)
 
-	servicesWithoutEndpoints, err := ProcessNamespaceServices(clientset, testNamespace, &filters.Options{})
+	servicesWithoutEndpoints, err := processNamespaceServices(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -80,6 +80,7 @@ func TestGetUnusedServicesStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedServices(&filters.Options{}, clientset, "json", opts)
@@ -89,7 +90,10 @@ func TestGetUnusedServicesStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Services": {"test-endpoint1", "test-endpoint4"},
+			"Service": {
+				"test-endpoint1",
+				"test-endpoint4",
+			},
 		},
 	}
 

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-func ProcessNamespaceStatefulSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+func processNamespaceStatefulSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	statefulSetsList, err := clientset.AppsV1().StatefulSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
@@ -40,35 +40,37 @@ func ProcessNamespaceStatefulSets(clientset kubernetes.Interface, namespace stri
 }
 
 func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]string)
-
-	for _, namespace := range namespaces {
-		diff, err := ProcessNamespaceStatefulSets(clientset, namespace, filterOpts)
+	resources := make(map[string]map[string][]string)
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceStatefulSets(clientset, namespace, filterOpts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
+		}
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["StatefulSet"] = diff
+		case "resource":
+			appendResources(resources, "StatefulSet", namespace, diff)
 		}
 		if opts.DeleteFlag {
 			if diff, err = DeleteResource(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Statefulset %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
-		output := FormatOutput(namespace, diff, "Statefulsets", opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-			outputBuffer.WriteString("\n")
-
-			resourceMap := make(map[string][]string)
-			resourceMap["Statefulsets"] = diff
-			response[namespace] = resourceMap
-		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedStatefulsets, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/statefulsets_test.go
+++ b/pkg/kor/statefulsets_test.go
@@ -57,7 +57,7 @@ func createTestStatefulSets(t *testing.T) *fake.Clientset {
 func TestProcessNamespaceStatefulSets(t *testing.T) {
 	clientset := createTestStatefulSets(t)
 
-	statefulSetsWithoutReplicas, err := ProcessNamespaceStatefulSets(clientset, testNamespace, &filters.Options{})
+	statefulSetsWithoutReplicas, err := processNamespaceStatefulSets(clientset, testNamespace, &filters.Options{})
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -80,6 +80,7 @@ func TestGetUnusedStatefulSetsStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedStatefulSets(&filters.Options{}, clientset, "json", opts)
@@ -89,7 +90,10 @@ func TestGetUnusedStatefulSetsStructured(t *testing.T) {
 
 	expectedOutput := map[string]map[string][]string{
 		testNamespace: {
-			"Statefulsets": {"test-sts1", "test-sts4"},
+			"StatefulSet": {
+				"test-sts1",
+				"test-sts4",
+			},
 		},
 	}
 

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -93,40 +93,34 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 }
 
 func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
-	var outputBuffer bytes.Buffer
-	response := make(map[string]map[string][]string)
-
+	resources := make(map[string]map[string][]string)
 	diff, err := processStorageClasses(clientset, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process storageClasses: %v\n", err)
 	}
-
-	if len(diff) > 0 {
-		// We consider cluster scope resources in "" (empty string) namespace, as it is common in k8s
-		if response[""] == nil {
-			response[""] = make(map[string][]string)
-		}
-		response[""]["StorageClass"] = diff
+	switch opts.GroupBy {
+	case "namespace":
+		resources[""] = make(map[string][]string)
+		resources[""]["StorageClass"] = diff
+	case "resource":
+		appendResources(resources, "StorageClass", "", diff)
 	}
-
 	if opts.DeleteFlag {
 		if diff, err = DeleteResource(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to delete StorageClass %s: %v\n", diff, err)
 		}
 	}
 
-	output := FormatOutput("", diff, "StorageClasses", opts)
-	if output != "" {
-		outputBuffer.WriteString(output)
-		outputBuffer.WriteString("\n")
-
-		response[""]["StorageClass"] = diff
-
-	}
-
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
 	unusedStorageClasses, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)

--- a/pkg/kor/storageclasses_test.go
+++ b/pkg/kor/storageclasses_test.go
@@ -75,6 +75,7 @@ func TestGetUnusedStorageClassesStructured(t *testing.T) {
 		Token:         "",
 		DeleteFlag:    false,
 		NoInteractive: true,
+		GroupBy:       "namespace",
 	}
 
 	output, err := GetUnusedStorageClasses(&filters.Options{}, clientset, "json", opts)


### PR DESCRIPTION
## What this PR does / why we need it
Adds a new flag `--group-by` to all subcommands of kor.
The value must be one of `namespace` or `resource`.
Please review the changes first; if all looks good, I will add tests.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes test for any new code

## Github Issue

Closes #43

## Notes for your reviewers
1. `kor all --group-by=resource`:
```
Unused ConfigMaps:
+---+-----------+---------------+
| # | NAMESPACE | RESOURCE NAME |
+---+-----------+---------------+
| 1 | ns1       | cm1           |
| 2 | ns1       | cm2           |
| 3 | ns2       | cm3           |
+---+-----------+---------------+
Unused Deployments:
+---+-----------+---------------+
| # | NAMESPACE | RESOURCE NAME |
+---+-----------+---------------+
| 1 | ns1       | deploy1       |
| 2 | ns2       | deploy2       |
+---+-----------+---------------+
Unused ReplicaSets:
+---+-----------+--------------------+
| # | NAMESPACE |   RESOURCE NAME    |
+---+-----------+--------------------+
| 1 | ns1       | deploy1-654d48b75f |
| 2 | ns2       | deploy2-79f48888c6 |
+---+-----------+--------------------+
```
2. `kor all --group-by=namespace`:
```
Unused resources in namespace: "ns1"
+---+---------------+--------------------+
| # | RESOURCE TYPE |   RESOURCE NAME    |
+---+---------------+--------------------+
| 1 | ConfigMap     | cm1                |
| 2 | ConfigMap     | cm2                |
| 3 | ReplicaSet    | deploy1-654d48b75f |
| 4 | Deployment    | deploy1            |
+---+---------------+--------------------+
Unused resources in namespace: "ns2"
+---+---------------+--------------------+
| # | RESOURCE TYPE |   RESOURCE NAME    |
+---+---------------+--------------------+
| 1 | ReplicaSet    | deploy2-79f48888c6 |
| 2 | ConfigMap     | cm3                |
| 3 | Deployment    | deploy2            |
+---+---------------+--------------------+
```