### PR TITLE
fix(GetUnusedAll): skip non-namespaced resources if --include-namespaces flag is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@
 [![codecov](https://codecov.io/gh/yonahd/kor/branch/main/graph/badge.svg?token=tNKcOjlxLo)](https://codecov.io/gh/yonahd/kor)
 [![Discord](https://discord.com/api/guilds/1159544275722321990/embed.png)](https://discord.gg/ajptYPwcJY)
 
-
-
 # Kor - Kubernetes Orphaned Resources Finder
 
 ![Kor Logo](/images/kor_logo.png)
 
 Kor is a tool to discover unused Kubernetes resources. Currently, Kor can identify and list unused:
+
 - ConfigMaps
 - Secrets
 - Services
@@ -38,18 +37,25 @@ Kor is a tool to discover unused Kubernetes resources. Currently, Kor can identi
 Download the binary for your operating system from the [releases page](https://github.com/yonahd/kor/releases) and add it to your system's PATH.
 
 ### Homebrew
+
 For macOS users, you can install Kor using Homebrew:
+
 ```sh
 brew install kor
 ```
+
 ### Build from source
+
 Install the binary to your `$GOBIN` or `$GOPATH/bin`:
+
 ```sh
 go install github.com/yonahd/kor@latest
 ```
 
 ### Docker
+
 Run a container with your kubeconfig mounted:
+
 ```sh
 docker run --rm -i yonahdissen/kor
 
@@ -57,12 +63,15 @@ docker run --rm -i -v "/path/to/.kube/config:/root/.kube/config" yonahdissen/kor
 ```
 
 ### Kubectl plugin (<img src="https://raw.githubusercontent.com/kubernetes-sigs/krew/master/assets/logo/horizontal/color/krew-horizontal-color.png" alt="krew" width="48"/>)
+
 ```sh
 kubectl krew install kor
 ```
 
 ### Helm
+
 Run as a cronjob in your Cluster (with an option for sending slack updates)
+
 ```sh
 helm upgrade -i kor \
     --namespace kor \
@@ -72,13 +81,13 @@ helm upgrade -i kor \
 ```
 
 Run as a deployment in your Cluster exposing prometheus metrics
+
 ```sh
 helm upgrade -i kor \
     --namespace kor \
     --create-namespace \
     ./charts/kor
 ```
-
 
 For more information see [in cluster usage](#in-cluster-usage)
 
@@ -111,13 +120,14 @@ Kor provides various subcommands to identify and list unused resources. The avai
 - `version` - Print kor version information.
 
 ### Supported Flags
+
 ```
       --delete                       Delete unused resources
   -l, --exclude-labels string        Selector to filter out, Example: --exclude-labels key1=value1,key2=value2. If --include-labels is set, --exclude-labels will be ignored.
-      --exclude-namespaces strings   Namespaces to be excluded, split by commas. Example: --exclude-namespace ns1,ns2,ns3. If --include-namespace is set, --exclude-namespaces will be ignored.
+      --exclude-namespaces strings   Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored.
   -h, --help                         help for kor
       --include-labels string        Selector to filter in, Example: --include-labels key1=value1,key2=value2.
-  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespace ns1,ns2,ns3.
+  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3.
   -k, --kubeconfig string            Path to kubeconfig file (optional)
       --newer-than string            The maximum age of the resources to be considered unused. This flag cannot be used together with older-than flag. Example: --newer-than=1h2m
       --no-interactive               Do not prompt for confirmation when deleting resources. Be careful using this flag!
@@ -143,54 +153,65 @@ kor [subcommand] --help
 
 ## Supported resources and limitations
 
-| Resource        | What it looks for                                                                                                                                                                                                                 | Known False Positives  ⚠️                                                                                                    |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| ConfigMaps      | ConfigMaps not used in the following places:<br/>- Pods<br/>- Containers<br/>- ConfigMaps used through Volumes<br/>- ConfigMaps used through environment variables                                                                | ConfigMaps used by resources which don't explicitly state them in the config.<br/> e.g Grafana dashboards loaded dynamically OPA policies fluentd configs CRD configs  |
-| Secrets         | Secrets not used in the following places:<br/>- Pods<br/>- Containers<br/>- Secrets used through volumes<br/>- Secrets used through environment variables<br/>- Secrets used by Ingress TLS<br/>- Secrets used by ServiceAccounts |    Secrets used by resources which don't explicitly state them in the config e.g. secrets used by CRDs                                                                                                                        |
-| Services        | Services with no endpoints                                                                                                                                                                                                        |                                                                                                                              |
-| Deployments     | Deployments with no Replicas                                                                                                                                                                                                      |                                                                                                                              |
-| ServiceAccounts | ServiceAccounts unused by Pods<br/>ServiceAccounts unused by roleBinding or clusterRoleBinding                                                                                                                                    |                                                                                                                              |
-| StatefulSets    | Statefulsets with no Replicas                                                                                                                                                                                                     |                                                                                                                              |
-| Roles           | Roles not used in roleBinding                                                                                                                                                                                                     |                                                                                                                              |
-| ClusterRoles    | ClusterRoles not used in roleBinding or clusterRoleBinding                                                                                                                                                                        |                                                                                                                              |
-| PVCs            | PVCs not used in Pods                                                                                                                                                                                                             |                                                                                                                              |
-| Ingresses       | Ingresses not pointing at any Service                                                                                                                                                                                             |                                                                                                                              |
-| Hpas            | HPAs not used in Deployments<br/> HPAs not used in StatefulSets                                                                                                                                                                   |                                                                                                                              |
-| CRDs            | CRDs not used the cluster                                                                                                                                                                                                         |                                                                                                                              |
-| Pvs             | PVs not bound to a PVC                                                                                                                                                                                                            |                                                                                                                              |
-| Pdbs            | PDBs not used in Deployments<br/> PDBs not used in StatefulSets                                                                                                                                                                   |                                                                                                                              |
-| Jobs            | Jobs status is completed                                                                                                                                                                                                          |                                                                                                                              |
+| Resource        | What it looks for                                                                                                                                                                                                                 | Known False Positives ⚠️                                                                                                                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ConfigMaps      | ConfigMaps not used in the following places:<br/>- Pods<br/>- Containers<br/>- ConfigMaps used through Volumes<br/>- ConfigMaps used through environment variables                                                                | ConfigMaps used by resources which don't explicitly state them in the config.<br/> e.g Grafana dashboards loaded dynamically OPA policies fluentd configs CRD configs |
+| Secrets         | Secrets not used in the following places:<br/>- Pods<br/>- Containers<br/>- Secrets used through volumes<br/>- Secrets used through environment variables<br/>- Secrets used by Ingress TLS<br/>- Secrets used by ServiceAccounts | Secrets used by resources which don't explicitly state them in the config e.g. secrets used by CRDs                                                                   |
+| Services        | Services with no endpoints                                                                                                                                                                                                        |                                                                                                                                                                       |
+| Deployments     | Deployments with no Replicas                                                                                                                                                                                                      |                                                                                                                                                                       |
+| ServiceAccounts | ServiceAccounts unused by Pods<br/>ServiceAccounts unused by roleBinding or clusterRoleBinding                                                                                                                                    |                                                                                                                                                                       |
+| StatefulSets    | Statefulsets with no Replicas                                                                                                                                                                                                     |                                                                                                                                                                       |
+| Roles           | Roles not used in roleBinding                                                                                                                                                                                                     |                                                                                                                                                                       |
+| ClusterRoles    | ClusterRoles not used in roleBinding or clusterRoleBinding                                                                                                                                                                        |                                                                                                                                                                       |
+| PVCs            | PVCs not used in Pods                                                                                                                                                                                                             |                                                                                                                                                                       |
+| Ingresses       | Ingresses not pointing at any Service                                                                                                                                                                                             |                                                                                                                                                                       |
+| Hpas            | HPAs not used in Deployments<br/> HPAs not used in StatefulSets                                                                                                                                                                   |                                                                                                                                                                       |
+| CRDs            | CRDs not used the cluster                                                                                                                                                                                                         |                                                                                                                                                                       |
+| Pvs             | PVs not bound to a PVC                                                                                                                                                                                                            |                                                                                                                                                                       |
+| Pdbs            | PDBs not used in Deployments<br/> PDBs not used in StatefulSets                                                                                                                                                                   |                                                                                                                                                                       |
+| Jobs            | Jobs status is completed                                                                                                                                                                                                          |                                                                                                                                                                       |
 | ReplicaSets     | replicaSets that specify replicas to 0 and has already completed it's work                                                                                                                                                        |
-| DaemonSets     | DaemonSets not scheduled on any nodes              |
-| StorageClasses | StorageClasses not used by any PVs/PVCs |
+| DaemonSets      | DaemonSets not scheduled on any nodes                                                                                                                                                                                             |
+| StorageClasses  | StorageClasses not used by any PVs/PVCs                                                                                                                                                                                           |
 
 ## Deleting Unused resources
+
 If you want to delete resources in an interactive way using Kor you can run:
+
 ```sh
 kor configmap --include-namespaces my-namespace --delete
 ```
+
 You will be prompted with:
+
 ```sh
 Do you want to delete ConfigMap test-configmap in namespace my-namespace? (Y/N):
 ```
 
 To delete with no prompt ( ⚠️ use with caution):
+
 ```sh
 kor configmap --include-namespaces my-namespace --delete --no-interactive
 ```
 
 ## Ignore Resources
+
 The resources labeled with:
+
 ```sh
 kor/used=true
 ```
+
 Will be ignored by kor even if they are unused. You can add this label to resources you want to ignore.
 
 ## Force clean Resources
+
 The resources labeled with:
+
 ```sh
 kor/used=false
 ```
+
 Will be cleaned always. This is a good way to mark resources for later cleanup.
 
 ## In Cluster Usage
@@ -215,6 +236,7 @@ helm upgrade -i kor \
     --set cronJob.slackToken=<slack-token> \
     ./charts/kor
 ```
+
 > Note: To send it to Slack as a file it's required to set the `slackToken` and `slackChannel` values.
 
 It's set to run every Monday at 1 a.m. by default. You can change the schedule by setting the `cronJob.schedule` value.
@@ -230,6 +252,7 @@ helm upgrade -i kor \
 ```
 
 ## Grafana Dashboard
+
 Dashboard can be found [here](https://grafana.com/grafana/dashboards/19863-kor-dashboard/).
 ![Grafana Dashboard](/grafana/dashboard-screenshot-1.png)
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --exclude-namespaces strings   Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored.
   -h, --help                         help for kor
       --include-labels string        Selector to filter in, Example: --include-labels key1=value1,key2=value2.
-  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3.
+  -n, --include-namespaces strings   Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored.
   -k, --kubeconfig string            Path to kubeconfig file (optional)
       --newer-than string            The maximum age of the resources to be considered unused. This flag cannot be used together with older-than flag. Example: --newer-than=1h2m
       --no-interactive               Do not prompt for confirmation when deleting resources. Be careful using this flag!

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -5,7 +5,7 @@ cronJob:
   image:
     repository: yonahdissen/kor
     tag: latest
-  # e.g. kor configmap --include-namespace default,other-ns
+  # e.g. kor configmap --include-namespaces default,other-ns
   command:
     - kor
   args:

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -80,6 +80,6 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringVar(&opts.NewerThan, "newer-than", opts.NewerThan, "The maximum age of the resources to be considered unused. This flag cannot be used together with older-than flag. Example: --newer-than=1h2m")
 	cmd.PersistentFlags().StringVar(&opts.OlderThan, "older-than", opts.OlderThan, "The minimum age of the resources to be considered unused. This flag cannot be used together with newer-than flag. Example: --older-than=1h2m")
 	cmd.PersistentFlags().StringVar(&opts.IncludeLabels, "include-labels", opts.IncludeLabels, "Selector to filter in, Example: --include-labels key1=value1.(currently supports one label)")
-	cmd.PersistentFlags().StringSliceVar(&opts.ExcludeNamespaces, "exclude-namespaces", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespace ns1,ns2,ns3. If --include-namespace is set, --exclude-namespaces will be ignored.")
-	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespace ns1,ns2,ns3. ")
+	cmd.PersistentFlags().StringSliceVar(&opts.ExcludeNamespaces, "exclude-namespaces", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored.")
+	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. ")
 }

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -81,5 +81,5 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringVar(&opts.OlderThan, "older-than", opts.OlderThan, "The minimum age of the resources to be considered unused. This flag cannot be used together with newer-than flag. Example: --older-than=1h2m")
 	cmd.PersistentFlags().StringVar(&opts.IncludeLabels, "include-labels", opts.IncludeLabels, "Selector to filter in, Example: --include-labels key1=value1.(currently supports one label)")
 	cmd.PersistentFlags().StringSliceVar(&opts.ExcludeNamespaces, "exclude-namespaces", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored.")
-	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. ")
+	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored.")
 }

--- a/pkg/filters/options.go
+++ b/pkg/filters/options.go
@@ -113,7 +113,7 @@ func (o *Options) Namespaces(clientset kubernetes.Interface) []string {
 		namespaces := make([]string, 0)
 		namespacesMap := make(map[string]bool)
 		if len(o.IncludeNamespaces) > 0 && len(o.ExcludeNamespaces) > 0 {
-			fmt.Fprintf(os.Stderr, "Exclude namespaces can't be used together with include namespaces. Ignoring --exclude-namespace(-e) flag\n")
+			fmt.Fprintf(os.Stderr, "Exclude namespaces can't be used together with include namespaces. Ignoring --exclude-namespaces (-e) flag\n")
 			o.ExcludeNamespaces = nil
 		}
 		includeNamespaces := o.IncludeNamespaces

--- a/pkg/filters/options.go
+++ b/pkg/filters/options.go
@@ -163,7 +163,7 @@ func (o *Options) Namespaces(clientset kubernetes.Interface) []string {
 func (o *Options) modifyLabels() {
 	if o.IncludeLabels != "" {
 		if len(o.ExcludeLabels) > 0 {
-			fmt.Fprintf(os.Stderr, "Exclude labels can't be used together with include labels. Ignoring --exclude-label(-l) flag\n")
+			fmt.Fprintf(os.Stderr, "Exclude labels can't be used together with include labels. Ignoring --exclude-labels (-l) flag\n")
 		}
 		o.ExcludeLabels = nil
 	}

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -313,6 +313,11 @@ func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, a
 		fmt.Printf("err: %v\n", err)
 	}
 
+	// Skip getting non-namespaced resources if --include-namespaces flag is used
+	if len(filterOpts.IncludeNamespaces) > 0 {
+		return unusedAllNamespaced, nil
+	}
+
 	unusedAllNonNamespaced, err := GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)


### PR DESCRIPTION
## What this PR does / why we need it

Currently, when running `kor all -n example`, unused non-namespaced resources will be displayed as well.
This PR fixes `GetUnusedAll()` function to skip non-namespaced resources if `--include-namespaces` flag is used.
`--include-namespaces` flag is considered used if the amount of listed namespaces is greater than 0.

In addition, this PR fixes flag typos across the code/docs:
- `--include-namespace` -> `--include-namespaces`
- `--exclude-namespace` -> `--exclude-namespaces`

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes test for any new code

## Github Issue

Resolves #178 

## Notes for your reviewers
`README.md` was automatically lintered by IDE, hence newline changes were commited, etc.