### PR TITLE
feat: add Kind exceptions

### DIFF
--- a/pkg/kor/exceptions/services/services.json
+++ b/pkg/kor/exceptions/services/services.json
@@ -7,6 +7,10 @@
     {
       "Namespace": "kube-system",
       "ResourceName": "vpa-recommender"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "docker.io-hostpath"
     }
   ]
 }


### PR DESCRIPTION
## What this PR does / why we need it
This PR excludes the default resources created in basic `kind` installations.
The only excluded resource in a default service created in macOS installation.

## PR Checklist

- [x] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [ ] This PR includes test for any new code

## Github Issue
Closes #235 

## Notes for your reviewers
I've tested `kind` both on Windows & Linux, and all the default unused resources are already covered by `kor` (added from other distros exclusions). The only difference is mentioned [here](https://github.com/yonahd/kor/pull/241#issuecomment-2077220002) but it was added in #252.

This PR adds exceptions from macOS installation.