### PR TITLE
feat: add K3S exceptions

### DIFF
--- a/pkg/kor/exceptions/clusterroles/clusterroles.json
+++ b/pkg/kor/exceptions/clusterroles/clusterroles.json
@@ -83,6 +83,14 @@
     {
       "Namespace": "",
       "ResourceName": "view"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:node-bootstrapper"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:aggregated-metrics-reader"
     }
   ]
 }

--- a/pkg/kor/exceptions/configmaps/configmaps.json
+++ b/pkg/kor/exceptions/configmaps/configmaps.json
@@ -79,6 +79,10 @@
     {
       "Namespace": "kubernetes-dashboard",
       "ResourceName": "kubernetes-dashboard-settings"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "cluster-dns"
     }
   ]
 }

--- a/pkg/kor/exceptions/crds/crds.json
+++ b/pkg/kor/exceptions/crds/crds.json
@@ -83,6 +83,86 @@
     {
       "Namespace": "",
       "ResourceName": "volumesnapshots.snapshot.storage.k8s.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "etcdsnapshotfiles.k3s.cattle.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "helmchartconfigs.helm.cattle.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ingressrouteudps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ingressrouteudps.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "middlewaretcps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ingressroutetcps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "serverstransports.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "middlewares.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "serverstransports.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "tlsstores.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "traefikservices.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "tlsstores.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "tlsoptions.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "traefikservices.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "serverstransporttcps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "middlewaretcps.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ingressroutes.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "tlsoptions.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ingressroutetcps.traefik.containo.us"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "middlewares.traefik.io"
     }
   ]
 }

--- a/pkg/kor/exceptions/jobs/jobs.json
+++ b/pkg/kor/exceptions/jobs/jobs.json
@@ -1,0 +1,13 @@
+{
+    "exceptionJobs": [
+      {
+        "Namespace": "kube-system",
+        "ResourceName": "helm-install-traefik-crd"
+      },
+      {
+        "Namespace": "kube-system",
+        "ResourceName": "helm-install-traefik"
+      }
+    ]
+  }
+  

--- a/pkg/kor/exceptions/secrets/secrets.json
+++ b/pkg/kor/exceptions/secrets/secrets.json
@@ -15,6 +15,14 @@
     {
       "Namespace": "kubernetes-dashboard",
       "ResourceName": "kubernetes-dashboard-key-holder"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "k3s-serving"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "*.node-password.k3s"
     }
   ]
 }

--- a/pkg/kor/exceptions/storageclasses/storageclasses.json
+++ b/pkg/kor/exceptions/storageclasses/storageclasses.json
@@ -43,6 +43,10 @@
     {
       "Namespace": "",
       "ResourceName": "standard-rwo"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "local-path"
     }
   ]
 }

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -13,8 +13,16 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+//go:embed exceptions/jobs/jobs.json
+var jobsConfig []byte
+
 func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
 	jobsList, err := clientset.BatchV1().Jobs(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := unmarshalConfig(jobsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -23,6 +31,10 @@ func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filt
 
 	for _, job := range jobsList.Items {
 		if pass, _ := filter.Run(filterOpts); pass {
+			continue
+		}
+
+		if isResourceException(job.Name, job.Namespace, config.ExceptionJobs) {
 			continue
 		}
 

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -38,6 +38,7 @@ type Config struct {
 	ExceptionServiceAccounts []ExceptionResource `json:"exceptionServiceAccounts"`
 	ExceptionServices        []ExceptionResource `json:"exceptionServices"`
 	ExceptionStorageClasses  []ExceptionResource `json:"exceptionStorageClasses"`
+	ExceptionJobs            []ExceptionResource `json:"exceptionJobs"`
 	// Add other configurations if needed
 }
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Adds exceptions to all k3s default objects.

## PR Checklist

- [x] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [ ] This PR includes test for any new code

## Github Issue

Fixes #259

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
Theres a default secret which is prefixed by the node's name. (e.g: `nodename.node-password.k3s`)
As wildcards work only as an indicator for a suffix I can't really really ignore it at the current state. <br />
I think the way forward will be one of the following options:

1. Allow wildcards/regex in the exception handling.
1. Allow `*` to be used as a prefix as well as a suffix.

I think option 1 has more risk of ignoring objects that aren't supposed to be ignored, so the second one seems more appealing to me. 
On the other hand, the second option is not as straightforward as well-known and used wildcards.
