### PR TITLE
feat: add helm chart testing

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -28,7 +28,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -46,7 +46,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           docker run --rm --volume "$(pwd):/helm-docs" jnorwood/helm-docs:latest
-          if ! git diff-index --quiet HEAD --; then
+          if ! git diff --exit-code; then
             echo "Error: Please update the chart README"
             echo "  docker run --rm --volume \"\$(pwd):/helm-docs\" jnorwood/helm-docs:latest"
             exit 1

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -42,6 +42,16 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
+      - name: Check README diff
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          docker run --rm --volume "$(pwd):/helm-docs" jnorwood/helm-docs:latest
+          if ! git diff-index --quiet HEAD --; then
+            echo "Error: Please update the chart README"
+            echo "  docker run --rm --volume \"\$(pwd):/helm-docs\" jnorwood/helm-docs:latest"
+            exit 1
+          fi
+
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.10.0

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,51 @@
+name: Lint and Test Charts
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - charts/**
+      - .github/workflows/helm-test.yaml
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.14.4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.10.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ main.exe
 coverage.txt
 build/
 kor
+!kor/

--- a/charts/kor/Chart.yaml
+++ b/charts/kor/Chart.yaml
@@ -2,5 +2,8 @@ apiVersion: v2
 name: kor
 description: A Kubernetes Helm Chart to discover orphaned resources using kor
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.4.0"
+maintainers:
+  - name: "yonahd"
+    url: "https://github.com/yonahd/kor"

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -1,8 +1,14 @@
 # kor
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Kubernetes Helm Chart to discover orphaned resources using kor
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| yonahd |  | <https://github.com/yonahd/kor> |
 
 ## Values
 

--- a/charts/kor/ci/cronjob-values.yaml
+++ b/charts/kor/ci/cronjob-values.yaml
@@ -1,0 +1,2 @@
+cronJob:
+  enabled: true


### PR DESCRIPTION
Add helm chart testing with https://github.com/helm/chart-testing-action

<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?

This PR adds some basic helm chart testing. It lints the chart and spins up a cluster to install the chart with each values file in `charts/kor/ci/*-values.yaml`.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
- [x] This PR add helm chart tests

## GitHub Issue

Should address https://github.com/yonahd/kor/issues/286

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

I just took the basic example from https://github.com/helm/chart-testing-action and applied it here. I ran `ct install` locally to test the chart, it correctly failed without the fixes from https://github.com/yonahd/kor/pull/292 and correctly passed when I applied the fixes.

I just set up default and "with cronjob" values since those are the two documented cases in the README.

I also had to modify the `.gitignore` because the `kor` entry was too broad and ended up ignoring things in `charts/kor`