### PR TITLE
chore: find kor exceptions script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,8 +16,4 @@ vendor/
 *.yml
 kor
 images
-
-.github
-*.yml
-kor
-images
+hack

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage.txt
 build/
 kor
 !kor/
+*.swp
+hack/exceptions

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,14 @@
+# Kor hack GuideLines
+
+This document describes how you can use the scripts from [`hack`](.) directory
+and gives a brief introduction and explanation of these scripts.
+
+## Overview
+
+The [`hack`](.) directory contains scripts that ensure continuous development of kor,
+enhance the robustness of the code, improve development efficiency, etc.
+The explanations and descriptions of these scripts are helpful for contributors.
+
+## Key scripts
+
+- [`find_exceptions.sh`](find_exceptions.sh): This script could be used to discover false-positive default resources in different K8s distributions. The output could be later merged into `pkg/kor/exceptions` for kor to ignore it in future releases.

--- a/hack/find_exceptions.sh
+++ b/hack/find_exceptions.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Find all unused resources in cluster
+all_json=$(kor all --group-by=resource -o json)
+
+# Read all top-level keys (resource types)
+resource_types=$(echo $all_json | jq -r 'keys[]')
+
+output_dir="exceptions"
+if [ -d "$output_dir" ]; then
+    rm -r "$output_dir"
+fi
+
+mkdir -p "$output_dir"
+
+# Process each resource type
+for resource_type in $resource_types; do
+  output_file="$output_dir/${resource_type,,}s.json"
+
+  # Format resource type exceptions
+  echo $all_json | jq --arg resource_type "$resource_type" '
+  {
+    ("exception" + ($resource_type) + "s"): [
+      .[$resource_type] | to_entries[] |
+      {
+        "Namespace": .key,
+        "ResourceName": .value[]
+      }
+    ]
+  }
+  ' > $output_file
+
+  echo "Processing completed for "$resource_type"s, output saved to $output_file"
+done


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR add a `hack` folder into kor, to include future useful scripts for contributors.
It also includes the initial script `find_exceptions.sh` to discover false-positive default resources, the output of this script could be merged to `pkg/kor/exceptions` to be ignored by kor.

This script should be used in issues like #236, #240 for intsance.

<details><summary>Output Example</summary>

```console
$ ./find_exceptions.sh
Processing completed for ConfigMaps, output saved to exceptions/configmaps.json
Processing completed for Secrets, output saved to exceptions/secrets.json
Processing completed for ServiceAccounts, output saved to exceptions/serviceaccounts.json

$ cat exceptions/configmaps.json
{
  "exceptionConfigMaps": [
    {
      "Namespace": "kube-system",
      "ResourceName": "bootstrap"
    },
    {
      "Namespace": "kube-system",
      "ResourceName": "cluster-config-v1"
    },
    {
      "Namespace": "kube-system",
      "ResourceName": "openshift-service-ca.crt"
    },
    {
      "Namespace": "kube-system",
      "ResourceName": "root-ca"
    }
  ]
}
```

</details>

> __**NOTE:**__ As `kor` outputs the resources in alphabet order (by Namespace and then by ResourceName), this script outputs the exception JSONs in a sorted way as well.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [x] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

[XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
The `find_exceptions.sh` **does not** squash resources that appear in multiple namespaces, for example, if a ConfigMap is created in every namespace, the output will not display as so:
```
    {
      "Namespace": "*",
      "ResourceName": "kube-root-ca.crt"
    }
```
The script eases the process to map the default resources, but requires manual intervention (regex, merging, etc).