### PR TITLE
feat: find unused networkpolicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
 - `replicaset` - Gets unused replicaSets for the specified namespace or all namespaces.
 - `daemonset`- Gets unused DaemonSets for the specified namespace or all namespaces.
 - `finalizer` - Gets unused pending deletion resources for the specified namespace or all namespaces.
+- `networkpolicy` - Gets unused NetworkPolicies for the specified namespace or all namespaces.
 - `exporter` - Export Prometheus metrics.
 - `version` - Print kor version information.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Kor is a tool to discover unused Kubernetes resources. Currently, Kor can identi
 - ReplicaSets
 - DaemonSets
 - StorageClasses
+- NetworkPolicies
 
 ![Kor Screenshot](/images/screenshot.png)
 
@@ -175,6 +176,7 @@ kor [subcommand] --help
 | ReplicaSets     | replicaSets that specify replicas to 0 and has already completed it's work                                                                                                                                                        |
 | DaemonSets      | DaemonSets not scheduled on any nodes                                                                                                                                                                                             |
 | StorageClasses  | StorageClasses not used by any PVs/PVCs                                                                                                                                                                                           |
+| NetworkPolicies  | NetworkPolicies with no Pods selected                                                                                                                                                                                           |
 
 ### Deleting Unused resources
 

--- a/charts/kor/Chart.yaml
+++ b/charts/kor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kor
 description: A Kubernetes Helm Chart to discover orphaned resources using kor
 type: application
-version: 0.1.7
-appVersion: "0.4.0"
+version: 0.1.8
+appVersion: "0.4.2"
 maintainers:
   - name: "yonahd"
     url: "https://github.com/yonahd/kor"

--- a/charts/kor/Chart.yaml
+++ b/charts/kor/Chart.yaml
@@ -3,7 +3,7 @@ name: kor
 description: A Kubernetes Helm Chart to discover orphaned resources using kor
 type: application
 version: 0.1.8
-appVersion: "0.4.2"
+appVersion: "0.4.3"
 maintainers:
   - name: "yonahd"
     url: "https://github.com/yonahd/kor"

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -1,6 +1,6 @@
 # kor
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 A Kubernetes Helm Chart to discover orphaned resources using kor
 

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -1,6 +1,6 @@
 # kor
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 A Kubernetes Helm Chart to discover orphaned resources using kor
 

--- a/charts/kor/templates/role.yaml
+++ b/charts/kor/templates/role.yaml
@@ -25,6 +25,7 @@ rules:
       - jobs
       - replicasets
       - daemonsets
+      - networkpolicies
     verbs:
       - get
       - list
@@ -56,6 +57,7 @@ rules:
       - jobs
       - replicasets
       - daemonsets
+      - networkpolicies
       {{/* cluster-scoped resources */}}
       - namespaces
       - clusterroles

--- a/cmd/kor/networkpolicies.go
+++ b/cmd/kor/networkpolicies.go
@@ -11,7 +11,7 @@ import (
 
 var netpolCmd = &cobra.Command{
 	Use:     "networkpolicy",
-	Aliases: []string{"networkpolicies", "netpol"},
+	Aliases: []string{"netpol", "networkpolicies"},
 	Short:   "Gets unused networkpolicies",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/kor/networkpolicies.go
+++ b/cmd/kor/networkpolicies.go
@@ -1,0 +1,30 @@
+package kor
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yonahd/kor/pkg/kor"
+	"github.com/yonahd/kor/pkg/utils"
+)
+
+var netpolCmd = &cobra.Command{
+	Use:     "networkpolicy",
+	Aliases: []string{"networkpolicies", "netpol"},
+	Short:   "Gets unused networkpolicies",
+	Args:    cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		clientset := kor.GetKubeClient(kubeconfig)
+		if response, err := kor.GetUnusedNetworkPolicies(filterOptions, clientset, outputFormat, opts); err != nil {
+			fmt.Println(err)
+		} else {
+			utils.PrintLogo(outputFormat)
+			fmt.Println(response)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(netpolCmd)
+}

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -254,7 +254,7 @@ func getUnusedStorageClasses(clientset kubernetes.Interface, filterOpts *filters
 func getUnusedNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
 	netpolDiff, err := processNamespaceNetworkPolicies(clientset, namespace, filterOpts)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "NetworkPolicy", namespace, err)
+		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "NetworkPolicies", namespace, err)
 	}
 	namespaceNetpolDiff := ResourceDiff{
 		"NetworkPolicy",

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -252,15 +252,15 @@ func getUnusedStorageClasses(clientset kubernetes.Interface, filterOpts *filters
 }
 
 func getUnusedNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
-	npDiff, err := processNamespaceNetworkPolicies(clientset, namespace, filterOpts)
+	netpolDiff, err := processNamespaceNetworkPolicies(clientset, namespace, filterOpts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "NetworkPolicy", namespace, err)
 	}
-	namespaceNPDiff := ResourceDiff{
+	namespaceNetpolDiff := ResourceDiff{
 		"NetworkPolicy",
-		npDiff,
+		netpolDiff,
 	}
-	return namespaceNPDiff
+	return namespaceNetpolDiff
 }
 
 func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -251,6 +251,18 @@ func getUnusedStorageClasses(clientset kubernetes.Interface, filterOpts *filters
 	return allScDiff
 }
 
+func getUnusedNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
+	npDiff, err := processNamespaceNetworkPolicies(clientset, namespace, filterOpts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "NetworkPolicy", namespace, err)
+	}
+	namespaceNPDiff := ResourceDiff{
+		"NetworkPolicy",
+		npDiff,
+	}
+	return namespaceNPDiff
+}
+
 func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
@@ -272,6 +284,7 @@ func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.In
 			resources[namespace]["Job"] = getUnusedJobs(clientset, namespace, filterOpts).diff
 			resources[namespace]["ReplicaSet"] = getUnusedReplicaSets(clientset, namespace, filterOpts).diff
 			resources[namespace]["DaemonSet"] = getUnusedDaemonSets(clientset, namespace, filterOpts).diff
+			resources[namespace]["NetworkPolicy"] = getUnusedNetworkPolicies(clientset, namespace, filterOpts).diff
 		case "resource":
 			appendResources(resources, "ConfigMap", namespace, getUnusedCMs(clientset, namespace, filterOpts).diff)
 			appendResources(resources, "Service", namespace, getUnusedSVCs(clientset, namespace, filterOpts).diff)
@@ -288,6 +301,7 @@ func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.In
 			appendResources(resources, "Job", namespace, getUnusedJobs(clientset, namespace, filterOpts).diff)
 			appendResources(resources, "ReplicaSet", namespace, getUnusedReplicaSets(clientset, namespace, filterOpts).diff)
 			appendResources(resources, "DaemonSet", namespace, getUnusedDaemonSets(clientset, namespace, filterOpts).diff)
+			appendResources(resources, "NetworkPolicy", namespace, getUnusedNetworkPolicies(clientset, namespace, filterOpts).diff)
 		}
 	}
 

--- a/pkg/kor/create_test_resources.go
+++ b/pkg/kor/create_test_resources.go
@@ -398,3 +398,16 @@ func CreateTestUnstructered(kind, apiVersion, namespace, name string) *unstructu
 		},
 	}
 }
+
+func CreateTestNetworkPolicies(name, namespace string, podSelector v1.LabelSelector, labels map[string]string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: podSelector,
+		},
+	}
+}

--- a/pkg/kor/create_test_resources.go
+++ b/pkg/kor/create_test_resources.go
@@ -399,7 +399,7 @@ func CreateTestUnstructered(kind, apiVersion, namespace, name string) *unstructu
 	}
 }
 
-func CreateTestNetworkPolicies(name, namespace string, podSelector v1.LabelSelector, labels map[string]string) *networkingv1.NetworkPolicy {
+func CreateTestNetworkPolicy(name, namespace string, podSelector v1.LabelSelector, labels map[string]string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,

--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -78,6 +78,9 @@ func DeleteResourceCmd() map[string]func(clientset kubernetes.Interface, namespa
 		"StorageClass": func(clientset kubernetes.Interface, namespace, name string) error {
 			return clientset.StorageV1().StorageClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
 		},
+		"NetworkPolicy": func(clientset kubernetes.Interface, namespace, name string) error {
+			return clientset.NetworkingV1().NetworkPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		},
 	}
 
 	return deleteResourceApiMap
@@ -165,6 +168,8 @@ func updateResource(clientset kubernetes.Interface, namespace, resourceType stri
 		return clientset.AppsV1().DaemonSets(namespace).Update(context.TODO(), resource.(*appsv1.DaemonSet), metav1.UpdateOptions{})
 	case "StorageClass":
 		return clientset.StorageV1().StorageClasses().Update(context.TODO(), resource.(*storagev1.StorageClass), metav1.UpdateOptions{})
+	case "NetworkPolicy":
+		return clientset.NetworkingV1().NetworkPolicies(namespace).Update(context.TODO(), resource.(*networkingv1.NetworkPolicy), metav1.UpdateOptions{})
 	}
 	return nil, fmt.Errorf("resource type '%s' is not supported", resourceType)
 }
@@ -207,6 +212,8 @@ func getResource(clientset kubernetes.Interface, namespace, resourceType, resour
 		return clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 	case "StorageClass":
 		return clientset.StorageV1().StorageClasses().Get(context.TODO(), resourceName, metav1.GetOptions{})
+	case "NetworkPolicy":
+		return clientset.NetworkingV1().NetworkPolicies(namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 	}
 	return nil, fmt.Errorf("resource type '%s' is not supported", resourceType)
 }

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -86,6 +86,8 @@ func retrieveNamespaceDiffs(clientset kubernetes.Interface, namespace string, re
 			diffResult = getUnusedReplicaSets(clientset, namespace, filterOpts)
 		case "ds", "daemonset", "daemonsets":
 			diffResult = getUnusedDaemonSets(clientset, namespace, filterOpts)
+		case "netpol", "networkpolicy", "networkpolicies":
+			diffResult = getUnusedNetworkPolicies(clientset, namespace, filterOpts)
 		default:
 			fmt.Printf("resource type %q is not supported\n", resource)
 		}

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -1,0 +1,98 @@
+package kor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/yonahd/kor/pkg/filters"
+)
+
+func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
+	netpolList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
+	if err != nil {
+		return nil, err
+	}
+
+	var unusedNetpols []string
+
+	for _, netpol := range netpolList.Items {
+		if pass := filters.KorLabelFilter(&netpol, filterOpts); pass {
+			continue
+		}
+
+		if netpol.Labels["kor/used"] == "false" {
+			unusedNetpols = append(unusedNetpols, netpol.Name)
+			continue
+		}
+
+		// retrieve pods selected by the NetworkPolicy
+		labelSelector, err := metav1.LabelSelectorAsSelector(&netpol.Spec.PodSelector)
+		if err != nil {
+			return nil, err
+		}
+		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labelSelector.String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(podList.Items) == 0 {
+			unusedNetpols = append(unusedNetpols, netpol.Name)
+		}
+	}
+
+	return unusedNetpols, nil
+}
+
+func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+	resources := make(map[string]map[string][]string)
+
+	for _, namespace := range filterOpts.Namespaces(clientset) {
+		diff, err := processNamespaceNetworkPolicies(clientset, namespace, filterOpts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
+			continue
+		}
+
+		switch opts.GroupBy {
+		case "namespace":
+			resources[namespace] = make(map[string][]string)
+			resources[namespace]["NetworkPolicy"] = diff
+		case "resource":
+			appendResources(resources, "NetworkPolicy", namespace, diff)
+		}
+
+		if opts.DeleteFlag {
+			if diff, err := DeleteResource(diff, clientset, namespace, "NetworkPolicy", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete NetworkPolicy %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
+	}
+
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
+	}
+
+	unusedNetworkPolcies, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+	}
+
+	return unusedNetworkPolcies, nil
+}

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"os"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/yonahd/kor/pkg/filters"
 )
 
 func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
-	netpolList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
+	netpolList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), v1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
 	}
@@ -32,11 +32,11 @@ func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace s
 		}
 
 		// retrieve pods selected by the NetworkPolicy
-		labelSelector, err := metav1.LabelSelectorAsSelector(&netpol.Spec.PodSelector)
+		labelSelector, err := v1.LabelSelectorAsSelector(&netpol.Spec.PodSelector)
 		if err != nil {
 			return nil, err
 		}
-		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), v1.ListOptions{
 			LabelSelector: labelSelector.String(),
 		})
 		if err != nil {
@@ -89,10 +89,10 @@ func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.
 		}
 	}
 
-	unusedNetworkPolcies, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
+	unusedNetworkPolicies, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 	}
 
-	return unusedNetworkPolcies, nil
+	return unusedNetworkPolicies, nil
 }

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"os"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/yonahd/kor/pkg/filters"
 )
 
 func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]string, error) {
-	netpolList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), v1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
+	netpolList, err := clientset.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
 	if err != nil {
 		return nil, err
 	}
@@ -32,11 +32,11 @@ func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace s
 		}
 
 		// retrieve pods selected by the NetworkPolicy
-		labelSelector, err := v1.LabelSelectorAsSelector(&netpol.Spec.PodSelector)
+		labelSelector, err := metav1.LabelSelectorAsSelector(&netpol.Spec.PodSelector)
 		if err != nil {
 			return nil, err
 		}
-		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), v1.ListOptions{
+		podList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: labelSelector.String(),
 		})
 		if err != nil {

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -8,7 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -20,8 +20,8 @@ func createTestNetworkPolicies(t *testing.T) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 
 	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
-	}, metav1.CreateOptions{})
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
 
 	if err != nil {
 		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
@@ -40,7 +40,7 @@ func createTestNetworkPolicies(t *testing.T) *fake.Clientset {
 	}
 
 	for _, pod := range pods {
-		_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod, v1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("Error creating fake pod: %v", err)
 		}
@@ -48,21 +48,21 @@ func createTestNetworkPolicies(t *testing.T) *fake.Clientset {
 
 	netpols := []*networkingv1.NetworkPolicy{
 		// all pods are selected
-		CreateTestNetworkPolicies("netpol-1", testNamespace, metav1.LabelSelector{}, AppLabels),
-		CreateTestNetworkPolicies("netpol-2", testNamespace, metav1.LabelSelector{}, UsedLabels),
-		CreateTestNetworkPolicies("netpol-3", testNamespace, metav1.LabelSelector{}, UnusedLabels),
+		CreateTestNetworkPolicy("netpol-1", testNamespace, v1.LabelSelector{}, AppLabels),
+		CreateTestNetworkPolicy("netpol-2", testNamespace, v1.LabelSelector{}, UsedLabels),
+		CreateTestNetworkPolicy("netpol-3", testNamespace, v1.LabelSelector{}, UnusedLabels),
 		// some pods are selected
-		CreateTestNetworkPolicies("netpol-4", testNamespace, *metav1.SetAsLabelSelector(podLabels), AppLabels),
-		CreateTestNetworkPolicies("netpol-5", testNamespace, *metav1.SetAsLabelSelector(podLabels), UnusedLabels),
-		CreateTestNetworkPolicies("netpol-6", testNamespace, *metav1.SetAsLabelSelector(podLabels), UsedLabels),
+		CreateTestNetworkPolicy("netpol-4", testNamespace, *v1.SetAsLabelSelector(podLabels), AppLabels),
+		CreateTestNetworkPolicy("netpol-5", testNamespace, *v1.SetAsLabelSelector(podLabels), UnusedLabels),
+		CreateTestNetworkPolicy("netpol-6", testNamespace, *v1.SetAsLabelSelector(podLabels), UsedLabels),
 		// no pods are selected
-		CreateTestNetworkPolicies("netpol-7", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), AppLabels),
-		CreateTestNetworkPolicies("netpol-8", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), UnusedLabels),
-		CreateTestNetworkPolicies("netpol-9", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), UsedLabels),
+		CreateTestNetworkPolicy("netpol-7", testNamespace, *v1.SetAsLabelSelector(noMatchLabels), AppLabels),
+		CreateTestNetworkPolicy("netpol-8", testNamespace, *v1.SetAsLabelSelector(noMatchLabels), UnusedLabels),
+		CreateTestNetworkPolicy("netpol-9", testNamespace, *v1.SetAsLabelSelector(noMatchLabels), UsedLabels),
 	}
 
 	for _, netpol := range netpols {
-		_, err = clientset.NetworkingV1().NetworkPolicies(netpol.Namespace).Create(context.TODO(), netpol, metav1.CreateOptions{})
+		_, err = clientset.NetworkingV1().NetworkPolicies(netpol.Namespace).Create(context.TODO(), netpol, v1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("Error creating fake networkpolicy: %v", err)
 		}
@@ -87,7 +87,7 @@ func TestProcessNamespaceNetworkPolicies(t *testing.T) {
 	}
 
 	if len(unusedNetpols) != len(expectedUnusedNetpols) {
-		t.Errorf("Expected %d  unused networkpolicies, got %d", len(expectedUnusedNetpols), len(unusedNetpols))
+		t.Errorf("Expected %d unused networkpolicies, got %d", len(expectedUnusedNetpols), len(unusedNetpols))
 	}
 
 	for i, netpol := range unusedNetpols {

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -91,7 +91,7 @@ func TestProcessNamespaceNetworkPolicies(t *testing.T) {
 	}
 
 	for i, netpol := range unusedNetpols {
-		if netpol != expectedUnusedNetpols[i] {
+		if netpol.Name != expectedUnusedNetpols[i] {
 			t.Errorf("Expected unused networkpolicy %s, got %s", expectedUnusedNetpols[i], netpol)
 		}
 	}

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -1,0 +1,142 @@
+package kor
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/yonahd/kor/pkg/filters"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func createTestNetworkPolicies(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	podLabels := map[string]string{
+		"app.kubernetes.io/name":    "my-app",
+		"app.kubernetes.io/version": "v1",
+		"product.my-org/name":       "my-app",
+	}
+	noMatchLabels := map[string]string{"app.kubernetes.io/version": "v2"}
+
+	pods := []*corev1.Pod{
+		CreateTestPod(testNamespace, "pod-1", "", nil, podLabels),
+		CreateTestPod(testNamespace, "pod-2", "", nil, AppLabels),
+	}
+
+	for _, pod := range pods {
+		_, err = clientset.CoreV1().Pods(testNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Error creating fake pod: %v", err)
+		}
+	}
+
+	netpols := []*networkingv1.NetworkPolicy{
+		// all pods are selected
+		CreateTestNetworkPolicies("netpol-1", testNamespace, metav1.LabelSelector{}, AppLabels),
+		CreateTestNetworkPolicies("netpol-2", testNamespace, metav1.LabelSelector{}, UsedLabels),
+		CreateTestNetworkPolicies("netpol-3", testNamespace, metav1.LabelSelector{}, UnusedLabels),
+		// some pods are selected
+		CreateTestNetworkPolicies("netpol-4", testNamespace, *metav1.SetAsLabelSelector(podLabels), AppLabels),
+		CreateTestNetworkPolicies("netpol-5", testNamespace, *metav1.SetAsLabelSelector(podLabels), UnusedLabels),
+		CreateTestNetworkPolicies("netpol-6", testNamespace, *metav1.SetAsLabelSelector(podLabels), UsedLabels),
+		// no pods are selected
+		CreateTestNetworkPolicies("netpol-7", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), AppLabels),
+		CreateTestNetworkPolicies("netpol-8", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), UnusedLabels),
+		CreateTestNetworkPolicies("netpol-9", testNamespace, *metav1.SetAsLabelSelector(noMatchLabels), UsedLabels),
+	}
+
+	for _, netpol := range netpols {
+		_, err = clientset.NetworkingV1().NetworkPolicies(netpol.Namespace).Create(context.TODO(), netpol, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Error creating fake networkpolicy: %v", err)
+		}
+	}
+
+	return clientset
+}
+
+func TestProcessNamespaceNetworkPolicies(t *testing.T) {
+	clientset := createTestNetworkPolicies(t)
+
+	unusedNetpols, err := processNamespaceNetworkPolicies(clientset, testNamespace, &filters.Options{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	expectedUnusedNetpols := []string{
+		"netpol-3",
+		"netpol-5",
+		"netpol-7",
+		"netpol-8",
+	}
+
+	if len(unusedNetpols) != len(expectedUnusedNetpols) {
+		t.Errorf("Expected %d  unused networkpolicies, got %d", len(expectedUnusedNetpols), len(unusedNetpols))
+	}
+
+	for i, netpol := range unusedNetpols {
+		if netpol != expectedUnusedNetpols[i] {
+			t.Errorf("Expected unused networkpolicy %s, got %s", expectedUnusedNetpols[i], netpol)
+		}
+	}
+}
+
+func TestGetUnusedNetworkPolicies(t *testing.T) {
+	clientset := createTestNetworkPolicies(t)
+
+	opts := Opts{
+		WebhookURL:    "",
+		Channel:       "",
+		Token:         "",
+		DeleteFlag:    false,
+		NoInteractive: true,
+		GroupBy:       "namespace",
+	}
+
+	output, err := GetUnusedNetworkPolicies(&filters.Options{}, clientset, "json", opts)
+	if err != nil {
+		t.Fatalf("Error calling GetUnusedNetworkPolicies: %v", err)
+	}
+
+	expectedOutput := map[string]map[string][]string{
+		testNamespace: {
+			"NetworkPolicy": []string{
+				"netpol-3",
+				"netpol-5",
+				"netpol-7",
+				"netpol-8",
+			},
+		},
+	}
+
+	var actualOutput map[string]map[string][]string
+	if err := json.Unmarshal([]byte(output), &actualOutput); err != nil {
+		t.Fatalf("Error unmarshaling actual output: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedOutput, actualOutput) {
+		t.Errorf("Expected output does not match actual output")
+		t.Errorf("Expected: %v", expectedOutput)
+		t.Errorf("Actual: %v", actualOutput)
+	}
+}
+
+func init() {
+	scheme.Scheme = runtime.NewScheme()
+	_ = networkingv1.AddToScheme(scheme.Scheme)
+}

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -6,13 +6,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yonahd/kor/pkg/filters"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/yonahd/kor/pkg/filters"
 )
 
 func createTestNetworkPolicies(t *testing.T) *fake.Clientset {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

## What this PR does / why we need it?

This PR added a new functionality to `kor` to find unused `NetworkPolicies`. A `NetworkPolicy` is considered unused when its label selector selects 0 pod or it has label `"kor/used"="false"`.

```bash
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused resources in namespace: "default"
+---+---------------+---------------------+
| # | RESOURCE TYPE |    RESOURCE NAME    |
+---+---------------+---------------------+
| 1 | NetworkPolicy | test-network-policy |
+---+---------------+---------------------+
```

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [x] This PR includes tests for new/existing code
- [x] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes #279 

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

This could be extended to check pods' status (e.g. `Succeeded`) but I am keeping it simple for now. Please let me know what you think^^
