### PR TITLE
refactor(cmd): standardize subcommand aliases with kubectl shortnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,24 +98,24 @@ Kor provides various subcommands to identify and list unused resources. The avai
 - `all` - Gets all unused resources for the specified namespace or all namespaces.
 - `configmap` - Gets unused ConfigMaps for the specified namespace or all namespaces.
 - `secret` - Gets unused Secrets for the specified namespace or all namespaces.
-- `services` - Gets unused Services for the specified namespace or all namespaces.
+- `service` - Gets unused Services for the specified namespace or all namespaces.
 - `serviceaccount` - Gets unused ServiceAccounts for the specified namespace or all namespaces.
-- `deployments` - Gets unused Deployments for the specified namespace or all namespaces.
-- `statefulsets` - Gets unused StatefulSets for the specified namespace or all namespaces.
+- `deployment` - Gets unused Deployments for the specified namespace or all namespaces.
+- `statefulset` - Gets unused StatefulSets for the specified namespace or all namespaces.
 - `role` - Gets unused Roles for the specified namespace or all namespaces.
 - `clusterrole` - Gets unused ClusterRoles for the specified namespace or all namespaces (namespace refers to RoleBinding).
 - `hpa` - Gets unused HPAs for the specified namespace or all namespaces.
-- `pods` - Gets unused Pods for the specified namespace or all namespaces.
+- `pod` - Gets unused Pods for the specified namespace or all namespaces.
 - `pvc` - Gets unused PVCs for the specified namespace or all namespaces.
 - `pv` - Gets unused PVs in the cluster (non namespaced resource).
-- `storageclasses` - Gets unused StorageClasses in the cluster (non namespaced resource).
+- `storageclass` - Gets unused StorageClasses in the cluster (non namespaced resource).
 - `ingress` - Gets unused Ingresses for the specified namespace or all namespaces.
 - `pdb` - Gets unused PDBs for the specified namespace or all namespaces.
 - `crd` - Gets unused CRDs in the cluster (non namespaced resource).
-- `jobs` - Gets unused jobs for the specified namespace or all namespaces.
-- `replicasets` - Gets unused replicaSets for the specified namespace or all namespaces.
-- `daemonsets`- Gets unused DaemonSets for the specified namespace or all namespaces.
-- `finalizers` - Gets unused pending deletion resources for the specified namespace or all namespaces.
+- `job` - Gets unused jobs for the specified namespace or all namespaces.
+- `replicaset` - Gets unused replicaSets for the specified namespace or all namespaces.
+- `daemonset`- Gets unused DaemonSets for the specified namespace or all namespaces.
+- `finalizer` - Gets unused pending deletion resources for the specified namespace or all namespaces.
 - `exporter` - Export Prometheus metrics.
 - `version` - Print kor version information.
 
@@ -217,7 +217,7 @@ Will be cleaned always. This is a good way to mark resources for later cleanup.
 
 ### Output Formats
 
-Kor supports three output formats: `table`, `json`, and `yaml`. The default output format is `table`.  
+Kor supports three output formats: `table`, `json`, and `yaml`. The default output format is `table`.
 Additionally, you can use the `--group-by` flag to group the output by `namespace` or `resource`.
 
 #### Group by resource

--- a/cmd/kor/crds.go
+++ b/cmd/kor/crds.go
@@ -11,7 +11,7 @@ import (
 
 var crdCmd = &cobra.Command{
 	Use:     "customresourcedefinition",
-	Aliases: []string{"crd", "customresourcedefinitions"},
+	Aliases: []string{"crd", "crds", "customresourcedefinitions"},
 	Short:   "Gets unused crds",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/kor/jobs.go
+++ b/cmd/kor/jobs.go
@@ -11,7 +11,7 @@ import (
 
 var jobCmd = &cobra.Command{
 	Use:     "job",
-	Aliases: []string{"job", "jobs"},
+	Aliases: []string{"jobs"},
 	Short:   "Gets unused jobs",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/kor/replicasets.go
+++ b/cmd/kor/replicasets.go
@@ -11,7 +11,7 @@ import (
 
 var replicaSetCmd = &cobra.Command{
 	Use:     "replicaset",
-	Aliases: []string{"rs", "replicaset", "replicasets"},
+	Aliases: []string{"rs", "replicasets"},
 	Short:   "Gets unused replicaSets",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/kor/secrets.go
+++ b/cmd/kor/secrets.go
@@ -11,7 +11,7 @@ import (
 
 var secretCmd = &cobra.Command{
 	Use:     "secret",
-	Aliases: []string{"scrt", "secrets"},
+	Aliases: []string{"secrets"},
 	Short:   "Gets unused secrets",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -218,7 +218,7 @@ func getUnusedJobs(clientset kubernetes.Interface, namespace string, filterOpts 
 func getUnusedReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ResourceDiff {
 	replicaSetDiff, err := processNamespaceReplicaSets(clientset, namespace, filterOpts)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "jobs", namespace, err)
+		fmt.Fprintf(os.Stderr, "Failed to get %s namespace %s: %v\n", "ReplicaSets", namespace, err)
 	}
 	namespaceRSDiff := ResourceDiff{
 		"ReplicaSet",

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -21,7 +21,7 @@ func retrieveNoNamespaceDiff(clientset kubernetes.Interface, apiExtClient apiext
 
 	for counter, resource := range resourceList {
 		switch resource {
-		case "crd", "customresourcedefinition", "customresourcedefinitions":
+		case "crd", "crds", "customresourcedefinition", "customresourcedefinitions":
 			crdDiff := getUnusedCrds(apiExtClient, dynamicClient, filterOpts)
 			noNamespaceDiff = append(noNamespaceDiff, crdDiff)
 			markedForRemoval[counter] = true
@@ -60,7 +60,7 @@ func retrieveNamespaceDiffs(clientset kubernetes.Interface, namespace string, re
 			diffResult = getUnusedCMs(clientset, namespace, filterOpts)
 		case "svc", "service", "services":
 			diffResult = getUnusedSVCs(clientset, namespace, filterOpts)
-		case "scrt", "secret", "secrets":
+		case "secret", "secrets":
 			diffResult = getUnusedSecrets(clientset, namespace, filterOpts)
 		case "sa", "serviceaccount", "serviceaccounts":
 			diffResult = getUnusedServiceAccounts(clientset, namespace, filterOpts)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR refactors subcommand aliases to match kubectl official shortnames, as disaplyed in `kubectl api-resources`.
Fixes:
- Remove excess singular aliases (i.e. "job", "replicaset")
- Remove unofficial shortnames (i.e. "scrt")
- Support uncovered shortnames (i.e. "crds")

In addition, this PR refactors the _Usage_ section in `README.md` to address kor's subcommands in singular form.

## PR Checklist

- [x] This PR adds new code
- [x] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

[XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
<details><summary>Kor Original Aliases</summary>

```console
$ grep -r Aliases cmd/kor/ -B 1
cmd/kor/clusterroles.go-        Use:     "clusterrole",
cmd/kor/clusterroles.go:        Aliases: []string{"clusterroles"},
--
cmd/kor/configmaps.go-  Use:     "configmap",
cmd/kor/configmaps.go:  Aliases: []string{"cm", "configmaps"},
--
cmd/kor/crds.go-        Use:     "customresourcedefinition",
cmd/kor/crds.go:        Aliases: []string{"crd", "customresourcedefinitions"},
--
cmd/kor/daemonsets.go-  Use:     "daemonset",
cmd/kor/daemonsets.go:  Aliases: []string{"ds", "daemonsets"},
--
cmd/kor/deployments.go- Use:     "deployment",
cmd/kor/deployments.go: Aliases: []string{"deploy", "deployments"},
--
cmd/kor/finalizers.go-  Use:     "finalizer",
cmd/kor/finalizers.go:  Aliases: []string{"fin", "finalizers"},
--
cmd/kor/hpas.go-        Use:     "horizontalpodautoscaler",
cmd/kor/hpas.go:        Aliases: []string{"hpa", "horizontalpodautoscalers"},
--
cmd/kor/ingresses.go-   Use:     "ingress",
cmd/kor/ingresses.go:   Aliases: []string{"ing", "ingresses"},
--
cmd/kor/jobs.go-        Use:     "job",
cmd/kor/jobs.go:        Aliases: []string{"job", "jobs"},
--
cmd/kor/pdbs.go-        Use:     "poddisruptionbudget",
cmd/kor/pdbs.go:        Aliases: []string{"pdb", "poddisruptionbudgets"},
--
cmd/kor/pods.go-        Use:     "pod",
cmd/kor/pods.go:        Aliases: []string{"po", "pods"},
--
cmd/kor/pv.go-  Use:     "persistentvolume",
cmd/kor/pv.go:  Aliases: []string{"pv", "persistentvolumes"},
--
cmd/kor/pvc.go- Use:     "persistentvolumeclaim",
cmd/kor/pvc.go: Aliases: []string{"pvc", "persistentvolumeclaims"},
--
cmd/kor/replicasets.go- Use:     "replicaset",
cmd/kor/replicasets.go: Aliases: []string{"rs", "replicaset", "replicasets"},
--
cmd/kor/roles.go-       Use:     "role",
cmd/kor/roles.go:       Aliases: []string{"roles"},
--
cmd/kor/secrets.go-     Use:     "secret",
cmd/kor/secrets.go:     Aliases: []string{"scrt", "secrets"},
--
cmd/kor/serviceaccounts.go-     Use:     "serviceaccount",
cmd/kor/serviceaccounts.go:     Aliases: []string{"sa", "serviceaccounts"},
--
cmd/kor/services.go-    Use:     "service",
cmd/kor/services.go:    Aliases: []string{"svc", "services"},
--
cmd/kor/statefulsets.go-        Use:     "statefulset",
cmd/kor/statefulsets.go:        Aliases: []string{"sts", "statefulsets"},
--
cmd/kor/storageclasses.go-      Use:     "storageclass",
cmd/kor/storageclasses.go:      Aliases: []string{"sc", "storageclassses"},
```
</details>

<details><summary>Kubectl Official Shortnames</summary>

```console
$ kubectl api-resources | awk '{print $1, $2}' | egrep -v '/|v1' | column -t
NAME                        SHORTNAMES
componentstatuses           cs
configmaps                  cm
endpoints                   ep
events                      ev
limitranges                 limits
namespaces                  ns
nodes                       no
persistentvolumeclaims      pvc
persistentvolumes           pv
pods                        po
replicationcontrollers      rc
resourcequotas              quota
serviceaccounts             sa
services                    svc
customresourcedefinitions   crd,crds
daemonsets                  ds
deployments                 deploy
replicasets                 rs
statefulsets                sts
horizontalpodautoscalers    hpa
cronjobs                    cj
certificatesigningrequests  csr
events                      ev
ingresses                   ing
networkpolicies             netpol
poddisruptionbudgets        pdb
priorityclasses             pc
storageclasses              sc
```
</details>