### PR TITLE
feat: Add OpenShift exceptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
 
 ## GitHub Issue
 
-[XX-XX]
+Closes [XX-XX]
 
 <!-- Notes that may be helpful for anyone reviewing this PR -->
 

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -124,6 +124,11 @@ func retrieveClusterRoleNames(clientset kubernetes.Interface, filterOpts *filter
 		return nil, nil, err
 	}
 
+	config, err := unmarshalConfig(clusterRolesConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var unusedClusterRoles []string
 	names := make([]string, 0, len(clusterRoles.Items))
 
@@ -135,11 +140,6 @@ func retrieveClusterRoleNames(clientset kubernetes.Interface, filterOpts *filter
 		if clusterRole.Labels["kor/used"] == "false" {
 			unusedClusterRoles = append(unusedClusterRoles, clusterRole.Name)
 			continue
-		}
-
-		config, err := unmarshalConfig(clusterRolesConfig)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		exceptionFound, err := isResourceException(clusterRole.Name, clusterRole.Namespace, config.ExceptionClusterRoles)

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -29,14 +29,14 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(crdsConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, crd := range crds.Items {
 		if pass := filters.KorLabelFilter(&crd, &filters.Options{}); pass {
 			continue
-		}
-
-		config, err := unmarshalConfig(crdsConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(crd.Name, crd.Namespace, config.ExceptionCrds)

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -23,16 +23,16 @@ func processNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(daemonsetsConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	var daemonSetsWithoutReplicas []ResourceInfo
 
 	for _, daemonSet := range daemonSetsList.Items {
 		if pass, _ := filter.SetObject(&daemonSet).Run(filterOpts); pass {
 			continue
-		}
-
-		config, err := unmarshalConfig(daemonsetsConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(daemonSet.Name, daemonSet.Namespace, config.ExceptionDaemonSets)

--- a/pkg/kor/exceptions/clusterroles/clusterroles.json
+++ b/pkg/kor/exceptions/clusterroles/clusterroles.json
@@ -6,11 +6,115 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "alert-routing-edit"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "cloud-provider"
     },
     {
       "Namespace": "",
+      "ResourceName": "cluster-debugger"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "global-operators-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "global-operators-edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "global-operators-view"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "monitoring-edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "monitoring-rules-edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "monitoring-rules-view"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "olm-operators-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "olm-operators-edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "olm-operators-view"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-cluster-monitoring-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-cluster-monitoring-edit"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-cluster-monitoring-view"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-main-attacher-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-main-provisioner-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-main-resizer-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-main-snapshotter-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-provisioner-configmap-and-secret-reader-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-provisioner-volumeattachment-reader-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-provisioner-volumesnapshot-reader-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-resizer-infrastructure-reader-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "openshift-csi-resizer-storageclass-reader-role"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "resource-metrics-server-resources"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "storage-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "sudoer"
     },
     {
       "Namespace": "",
@@ -35,6 +139,10 @@
     {
       "Namespace": "",
       "ResourceName": "system:auth-delegator"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:build-strategy-custom"
     },
     {
       "Namespace": "",
@@ -74,6 +182,18 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "system:image-auditor"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:image-pusher"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:image-signer"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "system:kube-aggregator"
     },
     {
@@ -94,7 +214,59 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "system:node-reader"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:aggregate-snapshots-to-storage-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:aggregate-to-storage-admin"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:hostaccess"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:hostmount"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:hostnetwork"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:nonroot"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:nonroot-v2"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:privileged"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:scc:restricted"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:openshift:templateservicebroker-client"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "system:persistent-volume-provisioner"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:router"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "system:sdn-manager"
     },
     {
       "Namespace": "",

--- a/pkg/kor/exceptions/configmaps/configmaps.json
+++ b/pkg/kor/exceptions/configmaps/configmaps.json
@@ -6,6 +6,11 @@
       "MatchRegex": true
     },
     {
+      "Namespace": ".*",
+      "ResourceName": "openshift-service-ca\\.crt",
+      "MatchRegex": true
+    },
+    {
       "Namespace": "gmp-system",
       "ResourceName": "config-images"
     },
@@ -27,7 +32,15 @@
     },
     {
       "Namespace": "kube-system",
+      "ResourceName": "bootstrap"
+    },
+    {
+      "Namespace": "kube-system",
       "ResourceName": "cluster-autoscaler-status"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "cluster-config-v1"
     },
     {
       "Namespace": "kube-system",
@@ -98,8 +111,17 @@
       "ResourceName": "overlay-upgrade-data"
     },
     {
+      "Namespace": "kube-system",
+      "ResourceName": "root-ca"
+    },
+    {
       "Namespace": "kubernetes-dashboard",
       "ResourceName": "kubernetes-dashboard-settings"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/exceptions/crds/crds.json
+++ b/pkg/kor/exceptions/crds/crds.json
@@ -2,6 +2,22 @@
   "exceptionCrds": [
     {
       "Namespace": "",
+      "ResourceName": "adminpolicybasedexternalroutes.k8s.ovn.org"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "alertingrules.monitoring.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "alertmanagerconfigs.monitoring.coreos.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "alertrelabelconfigs.monitoring.openshift.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "allowlistedv2workloads.auto.gke.io"
     },
     {
@@ -14,11 +30,31 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "baremetalhosts.metal3.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "bmceventsubscriptions.metal3.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "capacityrequests.internal.autoscaling.gke.io"
     },
     {
       "Namespace": "",
+      "ResourceName": "clusterautoscalers.autoscaling.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "clustercsidrivers.operator.openshift.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "clusterpodmonitorings.monitoring.googleapis.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "clusterresourcequotas.quota.openshift.io"
     },
     {
       "Namespace": "",
@@ -27,6 +63,58 @@
     {
       "Namespace": "",
       "ResourceName": "cninodes.vpcresources.k8s.aws"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "consoleexternalloglinks.console.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "consolelinks.console.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "consolenotifications.console.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "consolesamples.console.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "consoleyamlsamples.console.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "containerruntimeconfigs.machineconfiguration.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "controlplanemachinesets.machine.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "dnsrecords.ingress.operator.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "egressfirewalls.k8s.ovn.org"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "egressips.k8s.ovn.org"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "egressqoses.k8s.ovn.org"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "egressrouters.network.operator.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "egressservices.k8s.ovn.org"
     },
     {
       "Namespace": "",
@@ -42,6 +130,10 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "firmwareschemas.metal3.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "frontendconfigs.networking.gke.io"
     },
     {
@@ -54,11 +146,35 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "hardwaredata.metal3.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "helmchartconfigs.helm.cattle.io"
     },
     {
       "Namespace": "",
       "ResourceName": "helmchartconfigs.helm.cattle.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "hostfirmwaresettings.metal3.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "imagecontentpolicies.config.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "imagecontentsourcepolicies.operator.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "imagedigestmirrorsets.config.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "imagetagmirrorsets.config.openshift.io"
     },
     {
       "Namespace": "",
@@ -99,6 +215,30 @@
     {
       "Namespace": "",
       "ResourceName": "ingressrouteudps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "installplans.operators.coreos.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "ippools.whereabouts.cni.cncf.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "kubeletconfigs.machineconfiguration.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "machineautoscalers.autoscaling.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "machines.machine.openshift.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "machinesets.machine.openshift.io"
     },
     {
       "Namespace": "",
@@ -110,6 +250,14 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "metal3remediations.infrastructure.cluster.x-k8s.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "metal3remediationtemplates.infrastructure.cluster.x-k8s.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "middlewares.traefik.containo.us"
     },
     {
@@ -139,6 +287,10 @@
     {
       "Namespace": "",
       "ResourceName": "middlewaretcps.traefik.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "network-attachment-definitions.k8s.cni.cncf.io"
     },
     {
       "Namespace": "",
@@ -146,7 +298,23 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "operators.operators.coreos.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "overlappingrangeipreservations.whereabouts.cni.cncf.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "performanceprofiles.performance.openshift.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "podmonitorings.monitoring.googleapis.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "podmonitors.monitoring.coreos.com"
     },
     {
       "Namespace": "",
@@ -154,7 +322,27 @@
     },
     {
       "Namespace": "",
+      "ResourceName": "preprovisioningimages.metal3.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "probes.monitoring.coreos.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "projecthelmchartrepositories.helm.openshift.io"
+    },
+    {
+      "Namespace": "",
       "ResourceName": "provisioningrequests.autoscaling.x-k8s.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "provisionings.metal3.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "rolebindingrestrictions.authorization.openshift.io"
     },
     {
       "Namespace": "",
@@ -195,6 +383,18 @@
     {
       "Namespace": "",
       "ResourceName": "servicenetworkendpointgroups.networking.gke.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "storagestates.migration.k8s.io"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "subscriptions.operators.coreos.com"
+    },
+    {
+      "Namespace": "",
+      "ResourceName": "thanosrulers.monitoring.coreos.com"
     },
     {
       "Namespace": "",

--- a/pkg/kor/exceptions/jobs/jobs.json
+++ b/pkg/kor/exceptions/jobs/jobs.json
@@ -1,12 +1,21 @@
 {
   "exceptionJobs": [
     {
+      "Namespace": "assisted-installer",
+      "ResourceName": "assisted-installer-controller"
+    },
+    {
       "Namespace": "kube-system",
       "ResourceName": "helm-install-traefik"
     },
     {
       "Namespace": "kube-system",
       "ResourceName": "helm-install-traefik-crd"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/exceptions/pdbs/pdbs.json
+++ b/pkg/kor/exceptions/pdbs/pdbs.json
@@ -1,0 +1,9 @@
+{
+  "exceptionPdbs": [
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
+    }
+  ]
+}

--- a/pkg/kor/exceptions/replicasets/replicasets.json
+++ b/pkg/kor/exceptions/replicasets/replicasets.json
@@ -1,0 +1,9 @@
+{
+  "exceptionReplicaSets": [
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
+    }
+  ]
+}

--- a/pkg/kor/exceptions/replicasets/replicasets.json
+++ b/pkg/kor/exceptions/replicasets/replicasets.json
@@ -1,9 +1,0 @@
-{
-  "exceptionReplicaSets": [
-    {
-      "Namespace": "openshift-.*",
-      "ResourceName": ".*",
-      "MatchRegex": true
-    }
-  ]
-}

--- a/pkg/kor/exceptions/roles/roles.json
+++ b/pkg/kor/exceptions/roles/roles.json
@@ -7,6 +7,11 @@
     {
       "Namespace": "",
       "ResourceName": "system:controller:glbc"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/exceptions/secrets/secrets.json
+++ b/pkg/kor/exceptions/secrets/secrets.json
@@ -15,6 +15,14 @@
       "ResourceName": "k3s-serving"
     },
     {
+      "Namespace": "kube-system",
+      "ResourceName": "kube-cloud-cfg"
+    },
+    {
+      "Namespace": "kube-system",
+      "ResourceName": "kubeadmin"
+    },
+    {
       "Namespace": "kubernetes-dashboard",
       "ResourceName": "kubernetes-dashboard-certs"
     },
@@ -25,6 +33,11 @@
     {
       "Namespace": "kubernetes-dashboard",
       "ResourceName": "kubernetes-dashboard-key-holder"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/exceptions/serviceaccounts/serviceaccounts.json
+++ b/pkg/kor/exceptions/serviceaccounts/serviceaccounts.json
@@ -12,6 +12,11 @@
     {
       "Namespace": "kube-system",
       "ResourceName": "metadata-proxy"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/exceptions/services/services.json
+++ b/pkg/kor/exceptions/services/services.json
@@ -15,6 +15,11 @@
     {
       "Namespace": "kube-system",
       "ResourceName": "vpa-recommender"
+    },
+    {
+      "Namespace": "openshift-.*",
+      "ResourceName": ".*",
+      "MatchRegex": true
     }
   ]
 }

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -37,6 +37,8 @@ type Config struct {
 	ExceptionServices        []ExceptionResource `json:"exceptionServices"`
 	ExceptionStorageClasses  []ExceptionResource `json:"exceptionStorageClasses"`
 	ExceptionJobs            []ExceptionResource `json:"exceptionJobs"`
+	ExceptionPdbs            []ExceptionResource `json:"exceptionPdbs"`
+	ExceptionReplicaSets     []ExceptionResource `json:"exceptionReplicaSets"`
 	// Add other configurations if needed
 }
 

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -38,7 +38,6 @@ type Config struct {
 	ExceptionStorageClasses  []ExceptionResource `json:"exceptionStorageClasses"`
 	ExceptionJobs            []ExceptionResource `json:"exceptionJobs"`
 	ExceptionPdbs            []ExceptionResource `json:"exceptionPdbs"`
-	ExceptionReplicaSets     []ExceptionResource `json:"exceptionReplicaSets"`
 	// Add other configurations if needed
 }
 

--- a/pkg/kor/kor_test.go
+++ b/pkg/kor/kor_test.go
@@ -147,6 +147,11 @@ func getFakeExceptions() []ExceptionResource {
 			Namespace:    ".*",
 			MatchRegex:   true,
 		},
+		{
+			ResourceName: ".*",
+			Namespace:    "with-namespace-regex-prefix-.*",
+			MatchRegex:   true,
+		},
 	}
 }
 
@@ -175,6 +180,17 @@ func TestResourceExceptionWithRegexInName(t *testing.T) {
 func TestResourceExceptionWithRegexInNamespace(t *testing.T) {
 	exceptions := getFakeExceptions()
 	exceptionFound, err := isResourceException("with-namespace-regex", "default", exceptions)
+	if err != nil {
+		t.Error(err)
+	}
+	if !exceptionFound {
+		t.Error("Expected to find exception")
+	}
+}
+
+func TestResourceExceptionWithRegexPrefixInNamespace(t *testing.T) {
+	exceptions := getFakeExceptions()
+	exceptionFound, err := isResourceException("default", "with-namespace-regex-prefix-extra-text", exceptions)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -25,14 +25,14 @@ func processNamespacePdbs(clientset kubernetes.Interface, namespace string, filt
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(pdbsConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, pdb := range pdbs.Items {
 		if pass, _ := filter.SetObject(&pdb).Run(filterOpts); pass {
 			continue
-		}
-
-		config, err := unmarshalConfig(pdbsConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(pdb.Name, pdb.Namespace, config.ExceptionPdbs)

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/yonahd/kor/pkg/filters"
 )
+
+//go:embed exceptions/replicasets/replicasets.json
+var replicaSetsConfig []byte
 
 func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]ResourceInfo, error) {
 	replicaSetList, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
@@ -23,6 +27,20 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 
 	for _, replicaSet := range replicaSetList.Items {
 		if pass, _ := filter.Run(filterOpts); pass {
+			continue
+		}
+
+		config, err := unmarshalConfig(replicaSetsConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		exceptionFound, err := isResourceException(replicaSet.Name, replicaSet.Namespace, config.ExceptionReplicaSets)
+		if err != nil {
+			return nil, err
+		}
+
+		if exceptionFound {
 			continue
 		}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,16 +13,8 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
-//go:embed exceptions/replicasets/replicasets.json
-var replicaSetsConfig []byte
-
 func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace string, filterOpts *filters.Options) ([]ResourceInfo, error) {
 	replicaSetList, err := clientset.AppsV1().ReplicaSets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filterOpts.IncludeLabels})
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := unmarshalConfig(replicaSetsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -32,15 +23,6 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 
 	for _, replicaSet := range replicaSetList.Items {
 		if pass, _ := filter.Run(filterOpts); pass {
-			continue
-		}
-
-		exceptionFound, err := isResourceException(replicaSet.Name, replicaSet.Namespace, config.ExceptionReplicaSets)
-		if err != nil {
-			return nil, err
-		}
-
-		if exceptionFound {
 			continue
 		}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -23,16 +23,16 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(replicaSetsConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	var unusedReplicaSetNames []ResourceInfo
 
 	for _, replicaSet := range replicaSetList.Items {
 		if pass, _ := filter.Run(filterOpts); pass {
 			continue
-		}
-
-		config, err := unmarshalConfig(replicaSetsConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(replicaSet.Name, replicaSet.Namespace, config.ExceptionReplicaSets)

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -47,6 +47,12 @@ func retrieveRoleNames(clientset kubernetes.Interface, namespace string, filterO
 	if err != nil {
 		return nil, nil, err
 	}
+
+	config, err := unmarshalConfig(rolesConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var unusedRoleNames []string
 	names := make([]string, 0, len(roles.Items))
 	for _, role := range roles.Items {
@@ -56,11 +62,6 @@ func retrieveRoleNames(clientset kubernetes.Interface, namespace string, filterO
 		if role.Labels["kor/used"] == "false" {
 			unusedRoleNames = append(unusedRoleNames, role.Name)
 			continue
-		}
-
-		config, err := unmarshalConfig(rolesConfig)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		exceptionFound, err := isResourceException(role.Name, role.Namespace, config.ExceptionRoles)

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -19,6 +19,7 @@ import (
 var exceptionSecretTypes = []string{
 	`helm.sh/release.v1`,
 	`kubernetes.io/dockerconfigjson`,
+	`kubernetes.io/dockercfg`,
 	`kubernetes.io/service-account-token`,
 }
 

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -114,6 +114,11 @@ func retrieveSecretNames(clientset kubernetes.Interface, namespace string, filte
 		return nil, nil, err
 	}
 
+	config, err := unmarshalConfig(secretsConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var unusedSecretNames []string
 	names := make([]string, 0, len(secrets.Items))
 	for _, secret := range secrets.Items {
@@ -124,11 +129,6 @@ func retrieveSecretNames(clientset kubernetes.Interface, namespace string, filte
 		if secret.Labels["kor/used"] == "false" {
 			unusedSecretNames = append(unusedSecretNames, secret.Name)
 			continue
-		}
-
-		config, err := unmarshalConfig(secretsConfig)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		exceptionFound, err := isResourceException(secret.Name, secret.Namespace, config.ExceptionSecrets)

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -23,16 +23,16 @@ func processNamespaceServices(clientset kubernetes.Interface, namespace string, 
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(servicesConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	var endpointsWithoutSubsets []ResourceInfo
 
 	for _, endpoints := range endpointsList.Items {
 		if pass, _ := filter.Run(filterOpts); pass {
 			continue
-		}
-
-		config, err := unmarshalConfig(servicesConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(endpoints.Name, endpoints.Namespace, config.ExceptionServices)

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -56,6 +56,11 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 		return nil, err
 	}
 
+	config, err := unmarshalConfig(storageClassesConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	var unusedStorageClasses []ResourceInfo
 	storageClassNames := make([]string, 0, len(scs.Items))
 
@@ -67,11 +72,6 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 		if sc.Labels["kor/used"] == "false" {
 			unusedStorageClasses = append(unusedStorageClasses, ResourceInfo{Name: sc.Name, Reason: "Marked with unused label"})
 			continue
-		}
-
-		config, err := unmarshalConfig(storageClassesConfig)
-		if err != nil {
-			return nil, err
 		}
 
 		exceptionFound, err := isResourceException(sc.Name, sc.Namespace, config.ExceptionStorageClasses)


### PR DESCRIPTION
## What this PR does / why we need it
This PR excludes the default resources created in basic OpenShift installations.
In addition, I've moved the config load out of the processing loop in most resource types, to reduce excessive iterations.

## PR Checklist

- [x] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes test for any new code

## GitHub Issue

Closes #240

## Notes for your reviewers
In `pkg/kor/secrets.go`, a new exception secret type was added - `kubernetes.io/dockercfg`, which is the OpenShift equivalent of `kubernetes.io/dockerconfigjson`.

Basic OpenShift installation comes with 60+ namespaces beginning with `openshift-` prefix, which doesn't include additional namespaces created by OpenShift operators or customized installations, that would also be created with that prefix.
For that case, I've excluded all `openshift-` namespaces in all relevant namespaced resource types, with the following pattern:
```
    {
      "Namespace": "openshift-.*",
      "ResourceName": ".*",
      "MatchRegex": true
    }
```