### PR TITLE
fix: remove reason shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --no-interactive               Do not prompt for confirmation when deleting resources. Be careful using this flag!
       --older-than string            The minimum age of the resources to be considered unused. This flag cannot be used together with newer-than flag. Example: --older-than=1h2m
   -o, --output string                Output format (table, json or yaml) (default "table")
-  -r, --show-reason                  Print reason resource is considered unused
+      --show-reason                  Print reason resource is considered unused
       --slack-auth-token string      Slack auth token to send notifications to. --slack-auth-token requires --slack-channel to be set.
       --slack-channel string         Slack channel to send notifications to. --slack-channel requires --slack-auth-token to be set.
       --slack-webhook-url string     Slack webhook URL to send notifications to

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -60,7 +60,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Do not prompt for confirmation when deleting resources. Be careful using this flag!")
 	rootCmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output (print empty namespaces)")
 	rootCmd.PersistentFlags().StringVar(&opts.GroupBy, "group-by", "namespace", "Group output by (namespace, resource)")
-	rootCmd.PersistentFlags().BoolVarP(&opts.ShowReason, "show-reason", "r", false, "Print reason resource is considered unused")
+	rootCmd.PersistentFlags().BoolVar(&opts.ShowReason, "show-reason", false, "Print reason resource is considered unused")
 	addFilterOptionsFlag(rootCmd, filterOptions)
 }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Removes shorthand -r from reason as the flag is already taken.

## What this PR does / why we need it?

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [X] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

