### PR TITLE
fix(multi): Support grouping by resource in multi resource mode

### DIFF
--- a/pkg/kor/formatter.go
+++ b/pkg/kor/formatter.go
@@ -148,7 +148,7 @@ func formatOutputForResource(resource string, resources map[string][]ResourceInf
 		}
 	}
 	table.Render()
-	return fmt.Sprintf("Unused %ss:\n%s", resource, buf.String())
+	return fmt.Sprintf("Unused %ss:\n%s\n", resource, buf.String())
 }
 
 func appendResources(resources map[string]map[string][]ResourceInfo, resourceType, namespace string, diff []ResourceInfo) {

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -97,64 +97,64 @@ func retrieveNamespaceDiffs(clientset kubernetes.Interface, namespace string, re
 }
 
 func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
-	var allDiffs []ResourceDiff
-	var outputBuffer bytes.Buffer
-	var unusedMulti string
 	resourceList := strings.Split(resourceNames, ",")
 	namespaces := filterOpts.Namespaces(clientset)
-	response := make(map[string]map[string][]ResourceInfo)
+	resources := make(map[string]map[string][]ResourceInfo)
 	var err error
 
 	noNamespaceDiff, resourceList := retrieveNoNamespaceDiff(clientset, apiExtClient, dynamicClient, resourceList, filterOpts)
 	if len(noNamespaceDiff) != 0 {
 		for _, diff := range noNamespaceDiff {
 			if len(diff.diff) != 0 {
-				output := FormatOutputAll("", []ResourceDiff{diff}, opts)
-				outputBuffer.WriteString(output)
-
-				resourceMap := make(map[string][]ResourceInfo)
-				resourceMap[diff.resourceType] = diff.diff
-				response[""] = resourceMap
+				if opts.DeleteFlag {
+					if diff.diff, err = DeleteResource2(diff.diff, clientset, "", diff.resourceType, opts.NoInteractive); err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to delete %s %s: %v\n", diff.resourceType, diff.diff, err)
+					}
+				}
+				switch opts.GroupBy {
+				case "namespace":
+					resources[""] = make(map[string][]ResourceInfo)
+					resources[""][diff.resourceType] = diff.diff
+				case "resource":
+					appendResources(resources, diff.resourceType, "", diff.diff)
+				}
 			}
 		}
-
-		resourceMap := make(map[string][]ResourceInfo)
-		for _, diff := range noNamespaceDiff {
-			resourceMap[diff.resourceType] = diff.diff
-		}
-		response[""] = resourceMap
-
 	}
 
 	for _, namespace := range namespaces {
-		allDiffs = retrieveNamespaceDiffs(clientset, namespace, resourceList, filterOpts)
-
-		if opts.DeleteFlag {
-			for _, diff := range allDiffs {
-				if diff.diff, err = DeleteResource2(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", diff.resourceType, diff.diff, namespace, err)
+		allDiffs := retrieveNamespaceDiffs(clientset, namespace, resourceList, filterOpts)
+		for _, diff := range allDiffs {
+			if opts.DeleteFlag {
+				for _, diff := range allDiffs {
+					if diff.diff, err = DeleteResource2(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
+						fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", diff.resourceType, diff.diff, namespace, err)
+					}
 				}
 			}
-
-		}
-		output := FormatOutputAll(namespace, allDiffs, opts)
-		if output != "" {
-			outputBuffer.WriteString(output)
-
-			resourceMap := make(map[string][]ResourceInfo)
-			for _, diff := range allDiffs {
-				resourceMap[diff.resourceType] = diff.diff
+			switch opts.GroupBy {
+			case "namespace":
+				resources[namespace] = make(map[string][]ResourceInfo)
+				resources[namespace][diff.resourceType] = diff.diff
+			case "resource":
+				appendResources(resources, diff.resourceType, namespace, diff.diff)
 			}
-			response[namespace] = resourceMap
 		}
 	}
 
-	jsonResponse, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return "", err
+	var outputBuffer bytes.Buffer
+	var jsonResponse []byte
+	switch outputFormat {
+	case "table":
+		outputBuffer = FormatOutput(resources, opts)
+	case "json", "yaml":
+		var err error
+		if jsonResponse, err = json.MarshalIndent(resources, "", "  "); err != nil {
+			return "", err
+		}
 	}
 
-	unusedMulti, err = unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
+	unusedMulti, err := unusedResourceFormatter(outputFormat, outputBuffer, opts, jsonResponse)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 	}

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -126,10 +126,8 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 		allDiffs := retrieveNamespaceDiffs(clientset, namespace, resourceList, filterOpts)
 		for _, diff := range allDiffs {
 			if opts.DeleteFlag {
-				for _, diff := range allDiffs {
-					if diff.diff, err = DeleteResource(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
-						fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", diff.resourceType, diff.diff, namespace, err)
-					}
+				if diff.diff, err = DeleteResource(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", diff.resourceType, diff.diff, namespace, err)
 				}
 			}
 			switch opts.GroupBy {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR adds support to use `--group-by=resource` flag in multi resource mode.
In addition, it improves the output by adding newlines in similar to `--group-by=namespace` output.

```console
$ .\main.exe sa,clusterrole --group-by=resource -o json
{
  "ClusterRole": {
    "": [
      "aaa"
    ]
  },
  "ServiceAccount": {
    "kube-system": [
      "tes2t"
  }
}
```

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes #289 

<!-- Notes that may be helpful for anyone reviewing this PR -->

<!--## Notes for your reviewers-->
