### PR TITLE
fix(delete): Refactor input handling & output display on resource deletion 

### DIFF
--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -191,17 +191,17 @@ func GetUnusedClusterRoles(filterOpts *filters.Options, clientset kubernetes.Int
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process cluster role : %v\n", err)
 	}
+	if opts.DeleteFlag {
+		if diff, err = DeleteResource2(diff, clientset, "", "ClusterRole", opts.NoInteractive); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete clusterRole %s : %v\n", diff, err)
+		}
+	}
 	switch opts.GroupBy {
 	case "namespace":
 		resources[""] = make(map[string][]ResourceInfo)
 		resources[""]["ClusterRole"] = diff
 	case "resource":
 		appendResources(resources, "ClusterRole", "", diff)
-	}
-	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "ClusterRole", opts.NoInteractive); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete clusterRole %s : %v\n", diff, err)
-		}
 	}
 
 	var outputBuffer bytes.Buffer

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -192,7 +192,7 @@ func GetUnusedClusterRoles(filterOpts *filters.Options, clientset kubernetes.Int
 		fmt.Fprintf(os.Stderr, "Failed to process cluster role : %v\n", err)
 	}
 	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "ClusterRole", opts.NoInteractive); err != nil {
+		if diff, err = DeleteResource(diff, clientset, "", "ClusterRole", opts.NoInteractive); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to delete clusterRole %s : %v\n", diff, err)
 		}
 	}

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -166,17 +166,17 @@ func GetUnusedConfigmaps(filterOpts *filters.Options, clientset kubernetes.Inter
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "ConfigMap", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete ConfigMap %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["ConfigMap"] = diff
 		case "resource":
 			appendResources(resources, "ConfigMap", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ConfigMap", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete ConfigMap %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -167,7 +167,7 @@ func GetUnusedConfigmaps(filterOpts *filters.Options, clientset kubernetes.Inter
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ConfigMap", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "ConfigMap", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete ConfigMap %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -68,7 +68,7 @@ func GetUnusedDaemonSets(filterOpts *filters.Options, clientset kubernetes.Inter
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "DaemonSet", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "DaemonSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete DaemonSet %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -67,17 +67,17 @@ func GetUnusedDaemonSets(filterOpts *filters.Options, clientset kubernetes.Inter
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "DaemonSet", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete DaemonSet %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["DaemonSet"] = diff
 		case "resource":
 			appendResources(resources, "DaemonSet", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "DaemonSet", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete DaemonSet %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -270,58 +270,7 @@ func DeleteResourceWithFinalizer(resources []ResourceInfo, dynamicClient dynamic
 	return remainingResources, nil
 }
 
-func DeleteResource(diff []string, clientset kubernetes.Interface, namespace, resourceType string, noInteractive bool) ([]string, error) {
-	deletedDiff := []string{}
-
-	for _, resourceName := range diff {
-		deleteFunc, exists := DeleteResourceCmd()[resourceType]
-		if !exists {
-			fmt.Printf("Resource type '%s' is not supported\n", resourceName)
-			continue
-		}
-
-		if !noInteractive {
-			fmt.Printf("Do you want to delete %s %s in namespace %s? (Y/N): ", resourceType, resourceName, namespace)
-			var confirmation string
-			_, err := fmt.Scanf("%s", &confirmation)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
-				continue
-			}
-
-			if strings.ToLower(confirmation) != "y" && strings.ToLower(confirmation) != "yes" {
-				deletedDiff = append(deletedDiff, resourceName)
-
-				fmt.Printf("Do you want flag the resource %s %s in namespace %s as In Use? (Y/N): ", resourceType, resourceName, namespace)
-				var inUse string
-				_, err := fmt.Scanf("%s", &inUse)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
-					continue
-				}
-
-				if strings.ToLower(inUse) == "y" || strings.ToLower(inUse) == "yes" {
-					if err := FlagResource(clientset, namespace, resourceType, resourceName); err != nil {
-						fmt.Fprintf(os.Stderr, "Failed to flag resource %s %s in namespace %s as In Use: %v\n", resourceType, resourceName, namespace, err)
-					}
-					continue
-				}
-				continue
-			}
-		}
-
-		fmt.Printf("Deleting %s %s in namespace %s\n", resourceType, resourceName, namespace)
-		if err := deleteFunc(clientset, namespace, resourceName); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", resourceType, resourceName, namespace, err)
-			continue
-		}
-		deletedDiff = append(deletedDiff, resourceName+"-DELETED")
-	}
-
-	return deletedDiff, nil
-}
-
-func DeleteResource2(diff []ResourceInfo, clientset kubernetes.Interface, namespace, resourceType string, noInteractive bool) ([]ResourceInfo, error) {
+func DeleteResource(diff []ResourceInfo, clientset kubernetes.Interface, namespace, resourceType string, noInteractive bool) ([]ResourceInfo, error) {
 	deletedDiff := []ResourceInfo{}
 
 	for _, resource := range diff {

--- a/pkg/kor/delete.go
+++ b/pkg/kor/delete.go
@@ -334,7 +334,7 @@ func DeleteResource2(diff []ResourceInfo, clientset kubernetes.Interface, namesp
 		if !noInteractive {
 			fmt.Printf("Do you want to delete %s %s in namespace %s? (Y/N): ", resourceType, resource.Name, namespace)
 			var confirmation string
-			_, err := fmt.Scanf("%s", &confirmation)
+			_, err := fmt.Scanf("%s\n", &confirmation)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
 				continue
@@ -345,7 +345,7 @@ func DeleteResource2(diff []ResourceInfo, clientset kubernetes.Interface, namesp
 
 				fmt.Printf("Do you want flag the resource %s %s in namespace %s as In Use? (Y/N): ", resourceType, resource.Name, namespace)
 				var inUse string
-				_, err := fmt.Scanf("%s", &inUse)
+				_, err := fmt.Scanf("%s\n", &inUse)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
 					continue

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -49,17 +49,17 @@ func GetUnusedDeployments(filterOpts *filters.Options, clientset kubernetes.Inte
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Deployment", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Deployment %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Deployment"] = diff
 		case "resource":
 			appendResources(resources, "Deployment", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Deployment", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Deployment %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -50,7 +50,7 @@ func GetUnusedDeployments(filterOpts *filters.Options, clientset kubernetes.Inte
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Deployment", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Deployment", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Deployment %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -89,7 +89,7 @@ func GetUnusedHpas(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "HPA", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "HPA", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete HPA %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -88,17 +88,17 @@ func GetUnusedHpas(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "HPA", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete HPA %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Hpa"] = diff
 		case "resource":
 			appendResources(resources, "Hpa", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "HPA", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete HPA %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/ingresses.go
+++ b/pkg/kor/ingresses.go
@@ -124,17 +124,17 @@ func GetUnusedIngresses(filterOpts *filters.Options, clientset kubernetes.Interf
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Ingress", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Ingress %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Ingress"] = diff
 		case "resource":
 			appendResources(resources, "Ingress", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Ingress", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Ingress %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/ingresses.go
+++ b/pkg/kor/ingresses.go
@@ -125,7 +125,7 @@ func GetUnusedIngresses(filterOpts *filters.Options, clientset kubernetes.Interf
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Ingress", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Ingress", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Ingress %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -73,17 +73,17 @@ func GetUnusedJobs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Job", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Job %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Job"] = diff
 		case "resource":
 			appendResources(resources, "Job", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Job", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Job %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -74,7 +74,7 @@ func GetUnusedJobs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Job", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Job", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Job %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -131,7 +131,7 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 
 		if opts.DeleteFlag {
 			for _, diff := range allDiffs {
-				if diff.diff, err = DeleteResource2(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
+				if diff.diff, err = DeleteResource(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to delete %s %s in namespace %s: %v\n", diff.resourceType, diff.diff, namespace, err)
 				}
 			}

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -63,7 +63,7 @@ func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err := DeleteResource2(diff, clientset, namespace, "NetworkPolicy", opts.NoInteractive); err != nil {
+			if diff, err := DeleteResource(diff, clientset, namespace, "NetworkPolicy", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete NetworkPolicy %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -62,19 +62,17 @@ func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		if opts.DeleteFlag {
+			if diff, err := DeleteResource2(diff, clientset, namespace, "NetworkPolicy", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete NetworkPolicy %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["NetworkPolicy"] = diff
 		case "resource":
 			appendResources(resources, "NetworkPolicy", namespace, diff)
-		}
-
-		if opts.DeleteFlag {
-			if diff, err := DeleteResource2(diff, clientset, namespace, "NetworkPolicy", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete NetworkPolicy %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -90,7 +90,7 @@ func GetUnusedPdbs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "PDB", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "PDB", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete PDB %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -89,17 +89,17 @@ func GetUnusedPdbs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "PDB", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete PDB %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Pdb"] = diff
 		case "resource":
 			appendResources(resources, "Pdb", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "PDB", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete PDB %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -52,7 +52,7 @@ func GetUnusedPods(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Pod", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Pod", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Pod %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -51,17 +51,17 @@ func GetUnusedPods(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Pod", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Pod %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Pod"] = diff
 		case "resource":
 			appendResources(resources, "Pod", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Pod", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Pod %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -50,17 +50,17 @@ func GetUnusedPvs(filterOpts *filters.Options, clientset kubernetes.Interface, o
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process pvs: %v\n", err)
 	}
+	if opts.DeleteFlag {
+		if diff, err = DeleteResource2(diff, clientset, "", "PV", opts.NoInteractive); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete PV %s: %v\n", diff, err)
+		}
+	}
 	switch opts.GroupBy {
 	case "namespace":
 		resources[""] = make(map[string][]ResourceInfo)
 		resources[""]["Pv"] = diff
 	case "resource":
 		appendResources(resources, "Pv", "", diff)
-	}
-	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "PV", opts.NoInteractive); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete PV %s: %v\n", diff, err)
-		}
 	}
 
 	var outputBuffer bytes.Buffer

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -51,7 +51,7 @@ func GetUnusedPvs(filterOpts *filters.Options, clientset kubernetes.Interface, o
 		fmt.Fprintf(os.Stderr, "Failed to process pvs: %v\n", err)
 	}
 	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "PV", opts.NoInteractive); err != nil {
+		if diff, err = DeleteResource(diff, clientset, "", "PV", opts.NoInteractive); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to delete PV %s: %v\n", diff, err)
 		}
 	}

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -80,17 +80,17 @@ func GetUnusedPvcs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "PVC", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete PVC %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Pvc"] = diff
 		case "resource":
 			appendResources(resources, "Pvc", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "PVC", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete PVC %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -81,7 +81,7 @@ func GetUnusedPvcs(filterOpts *filters.Options, clientset kubernetes.Interface, 
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "PVC", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "PVC", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete PVC %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -44,17 +44,17 @@ func GetUnusedReplicaSets(filterOpts *filters.Options, clientset kubernetes.Inte
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "ReplicaSet", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete ReplicaSet %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["ReplicaSet"] = diff
 		case "resource":
 			appendResources(resources, "ReplicaSet", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ReplicaSet", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete ReplicaSet %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -45,7 +45,7 @@ func GetUnusedReplicaSets(filterOpts *filters.Options, clientset kubernetes.Inte
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ReplicaSet", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "ReplicaSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete ReplicaSet %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -114,7 +114,7 @@ func GetUnusedRoles(filterOpts *filters.Options, clientset kubernetes.Interface,
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Role", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Role", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Role %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -113,17 +113,17 @@ func GetUnusedRoles(filterOpts *filters.Options, clientset kubernetes.Interface,
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Role", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Role %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Role"] = diff
 		case "resource":
 			appendResources(resources, "Role", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Role", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Role %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -204,7 +204,7 @@ func GetUnusedSecrets(filterOpts *filters.Options, clientset kubernetes.Interfac
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Secret", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Secret", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Secret %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -203,17 +203,17 @@ func GetUnusedSecrets(filterOpts *filters.Options, clientset kubernetes.Interfac
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Secret", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Secret %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["Secret"] = diff
 		case "resource":
 			appendResources(resources, "Secret", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Secret", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Secret %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -172,7 +172,7 @@ func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Serviceaccount %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -171,17 +171,17 @@ func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Serviceaccount %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			resources[namespace] = make(map[string][]ResourceInfo)
 			resources[namespace]["ServiceAccount"] = diff
 		case "resource":
 			appendResources(resources, "ServiceAccount", namespace, diff)
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "ServiceAccount", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Serviceaccount %s in namespace %s: %v\n", diff, namespace, err)
-			}
 		}
 	}
 

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -69,7 +69,7 @@ func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interfa
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Service", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "Service", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Service %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -68,7 +68,11 @@ func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interfa
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
-
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "Service", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Service %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			if diff != nil {
@@ -78,13 +82,6 @@ func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interfa
 		case "resource":
 			if diff != nil {
 				appendResources(resources, "Service", namespace, diff)
-			}
-
-		}
-
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "Service", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Service %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
 	}

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -51,6 +51,11 @@ func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Int
 			fmt.Fprintf(os.Stderr, "Failed to process namespace %s: %v\n", namespace, err)
 			continue
 		}
+		if opts.DeleteFlag {
+			if diff, err = DeleteResource2(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to delete Statefulset %s in namespace %s: %v\n", diff, namespace, err)
+			}
+		}
 		switch opts.GroupBy {
 		case "namespace":
 			if diff != nil {
@@ -60,11 +65,6 @@ func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Int
 		case "resource":
 			if diff != nil {
 				appendResources(resources, "StatefulSet", namespace, diff)
-			}
-		}
-		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to delete Statefulset %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}
 	}

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -52,7 +52,7 @@ func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Int
 			continue
 		}
 		if opts.DeleteFlag {
-			if diff, err = DeleteResource2(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
+			if diff, err = DeleteResource(diff, clientset, namespace, "StatefulSet", opts.NoInteractive); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to delete Statefulset %s in namespace %s: %v\n", diff, namespace, err)
 			}
 		}

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -104,17 +104,17 @@ func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.I
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to process storageClasses: %v\n", err)
 	}
+	if opts.DeleteFlag {
+		if diff, err = DeleteResource2(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete StorageClass %s: %v\n", diff, err)
+		}
+	}
 	switch opts.GroupBy {
 	case "namespace":
 		resources[""] = make(map[string][]ResourceInfo)
 		resources[""]["StorageClass"] = diff
 	case "resource":
 		appendResources(resources, "StorageClass", "", diff)
-	}
-	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete StorageClass %s: %v\n", diff, err)
-		}
 	}
 
 	var outputBuffer bytes.Buffer

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -105,7 +105,7 @@ func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.I
 		fmt.Fprintf(os.Stderr, "Failed to process storageClasses: %v\n", err)
 	}
 	if opts.DeleteFlag {
-		if diff, err = DeleteResource2(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
+		if diff, err = DeleteResource(diff, clientset, "", "StorageClass", opts.NoInteractive); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to delete StorageClass %s: %v\n", diff, err)
 		}
 	}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR aims to resolve 2 outputing issues resulting in the `--delete` flag.
1. Avoid the unexpected newline error on confirmation
2. Append `-DELETED` suffix on deleted resources in output

```console
$ .\main.exe clusterrole --delete
Do you want to delete ClusterRole aaa in namespace ? (Y/N): y
Deleting ClusterRole aaa in namespace
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused resources in namespace: ""
+---+---------------+---------------+
| # | RESOURCE TYPE | RESOURCE NAME |
+---+---------------+---------------+
| 1 | ClusterRole   | aaa-DELETED   |
+---+---------------+---------------+
```

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes #321
Closes #322 

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
#321 is resolved by consuming the newline character ("\n") and removing it from the input buffer.
#322 is resolved by moving the deletion logic before the grouping logic, so the updated `diff` variable will be used.