### PR TITLE
fix(workflow): move chart release workflow and fix fetch-depth bug

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,29 @@
+name: Release Charts
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  chart-release:
+    name: Chart Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+          env:
+            GITHUB_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4
-          env:
-            GITHUB_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,3 @@ jobs:
       - name: Update new version in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.46
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
-          


### PR DESCRIPTION
## What this PR does / why we need it?
- Moved the Helm chart release steps from release.yml to a new chart-release.yml workflow for better separation of concerns.
- Fixed a bug where the chart-releaser-action wouldn't find changes by adding fetch-depth: 0 in the checkout step.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
- [X] This PR changes the project workflow

## GitHub Issue

Closes #325 

## Notes for your reviewers
- Moved the Helm chart release steps from `release.yml` to `chart-release.yml` for better separation of concerns and to avoid slowing down the main CI process with `fetch-depth: 0`.
