### PR TITLE
chore: move slack to utils directory

### DIFF
--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 	"github.com/yonahd/kor/pkg/kor"
 	"github.com/yonahd/kor/pkg/utils"
@@ -46,7 +47,7 @@ var rootCmd = &cobra.Command{
 var (
 	outputFormat  string
 	kubeconfig    string
-	opts          kor.Opts
+	opts          common.Opts
 	filterOptions = &filters.Options{}
 )
 

--- a/pkg/common/params.go
+++ b/pkg/common/params.go
@@ -1,0 +1,12 @@
+package common
+
+type Opts struct {
+	DeleteFlag    bool
+	NoInteractive bool
+	Verbose       bool
+	WebhookURL    string
+	Channel       string
+	Token         string
+	GroupBy       string
+	ShowReason    bool
+}

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -263,7 +264,7 @@ func getUnusedNetworkPolicies(clientset kubernetes.Interface, namespace string, 
 	return namespaceNetpolDiff
 }
 
-func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		switch opts.GroupBy {
@@ -325,7 +326,7 @@ func GetUnusedAllNamespaced(filterOpts *filters.Options, clientset kubernetes.In
 	return unusedAllNamespaced, nil
 }
 
-func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	switch opts.GroupBy {
 	case "namespace":
@@ -361,7 +362,7 @@ func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes
 	return unusedAllNonNamespaced, nil
 }
 
-func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
 	unusedAllNamespaced, err := GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 	"strconv"
 
@@ -16,6 +15,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 	"strconv"
 
@@ -179,7 +180,7 @@ func processClusterRoles(clientset kubernetes.Interface, filterOpts *filters.Opt
 
 }
 
-func GetUnusedClusterRoles(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedClusterRoles(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	diff, err := processClusterRoles(clientset, filterOpts)
 	if err != nil {

--- a/pkg/kor/clusterroles_test.go
+++ b/pkg/kor/clusterroles_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"sort"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/clusterroles_test.go
+++ b/pkg/kor/clusterroles_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"sort"
 	"testing"
@@ -138,7 +139,7 @@ func TestProcessClusterRoles(t *testing.T) {
 func TestGetUnusedClusterRolesStructured(t *testing.T) {
 	clientset := createTestClusterRoles(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -158,7 +158,7 @@ func processNamespaceCM(clientset kubernetes.Interface, namespace string, filter
 	return diff, nil
 }
 
-func GetUnusedConfigmaps(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedConfigmaps(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceCM(clientset, namespace, filterOpts)

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/configmaps_test.go
+++ b/pkg/kor/configmaps_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/configmaps_test.go
+++ b/pkg/kor/configmaps_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -197,7 +198,7 @@ func TestRetrieveUsedCM(t *testing.T) {
 func TestGetUnusedConfigmapsStructured(t *testing.T) {
 	clientset := createTestConfigmaps(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -65,7 +65,7 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 	return unusedCRDs, nil
 }
 
-func GetUnusedCrds(_ *filters.Options, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedCrds(_ *filters.Options, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	diff, err := processCrds(apiExtClient, dynamicClient, &filters.Options{})
 	if err != nil {

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -6,12 +6,12 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +60,7 @@ func processNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 	return daemonSetsWithoutReplicas, nil
 }
 
-func GetUnusedDaemonSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedDaemonSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceDaemonSets(clientset, namespace, filterOpts)

--- a/pkg/kor/daemonsets_test.go
+++ b/pkg/kor/daemonsets_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/daemonsets_test.go
+++ b/pkg/kor/daemonsets_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -82,7 +83,7 @@ func TestProcessNamespaceDaemonSets(t *testing.T) {
 func TestGetUnusedDaemonSetsStructured(t *testing.T) {
 	clientset := createTestDaemonSets(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -41,7 +41,7 @@ func processNamespaceDeployments(clientset kubernetes.Interface, namespace strin
 	return deploymentsWithoutReplicas, nil
 }
 
-func GetUnusedDeployments(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedDeployments(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceDeployments(clientset, namespace, filterOpts)

--- a/pkg/kor/deployments_test.go
+++ b/pkg/kor/deployments_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/deployments_test.go
+++ b/pkg/kor/deployments_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -74,7 +75,7 @@ func TestProcessNamespaceDeployments(t *testing.T) {
 func TestGetUnusedDeploymentsStructured(t *testing.T) {
 	clientset := createTestDeployments(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 // TODO: add option to change port / url !?
-func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) {
+func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
 	http.Handle("/metrics", promhttp.Handler())
 	fmt.Println("Server listening on :8080")
 	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList) // Start exporting metrics in the background
@@ -42,7 +42,7 @@ func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, ap
 	}
 }
 
-func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) {
+func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
 	exporterInterval := os.Getenv("EXPORTER_INTERVAL")
 	if exporterInterval == "" {
 		exporterInterval = "10"
@@ -79,7 +79,7 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 	}
 }
 
-func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts, resourceList []string) (string, error) {
+func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) (string, error) {
 	if len(resourceList) == 0 || (len(resourceList) == 1 && resourceList[0] == "all") {
 		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 	}

--- a/pkg/kor/finalizers.go
+++ b/pkg/kor/finalizers.go
@@ -14,6 +14,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/finalizers.go
+++ b/pkg/kor/finalizers.go
@@ -78,7 +78,7 @@ func getResourcesWithFinalizersPendingDeletion(clientset kubernetes.Interface, d
 	return retrievePendingDeletionResources(resourceTypes, dynamicClient, filterOpts)
 }
 
-func GetUnusedfinalizers(filterOpts *filters.Options, clientset kubernetes.Interface, dynamicClient *dynamic.DynamicClient, outputFormat string, opts Opts) (string, error) {
+func GetUnusedfinalizers(filterOpts *filters.Options, clientset kubernetes.Interface, dynamicClient *dynamic.DynamicClient, outputFormat string, opts common.Opts) (string, error) {
 	var outputBuffer bytes.Buffer
 	namespaces := filterOpts.Namespaces(clientset)
 	response := make(map[string]map[string][]ResourceInfo)

--- a/pkg/kor/formatter.go
+++ b/pkg/kor/formatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -24,7 +25,7 @@ func getTableRow(index int, columns ...string) []string {
 	return row
 }
 
-func unusedResourceFormatter(outputFormat string, outputBuffer bytes.Buffer, opts Opts, jsonResponse []byte) (string, error) {
+func unusedResourceFormatter(outputFormat string, outputBuffer bytes.Buffer, opts common.Opts, jsonResponse []byte) (string, error) {
 	switch outputFormat {
 	case "table":
 		if opts.WebhookURL == "" || opts.Channel == "" || opts.Token != "" {
@@ -83,7 +84,7 @@ func unusedResourceFormatter(outputFormat string, outputBuffer bytes.Buffer, opt
 	return "", fmt.Errorf("unsupported output format: %s", outputFormat)
 }
 
-func FormatOutput(resources map[string]map[string][]ResourceInfo, opts Opts) bytes.Buffer {
+func FormatOutput(resources map[string]map[string][]ResourceInfo, opts common.Opts) bytes.Buffer {
 	var output bytes.Buffer
 	switch opts.GroupBy {
 	case "namespace":
@@ -98,7 +99,7 @@ func FormatOutput(resources map[string]map[string][]ResourceInfo, opts Opts) byt
 	return output
 }
 
-func formatOutputForNamespace(namespace string, resources map[string][]ResourceInfo, opts Opts) string {
+func formatOutputForNamespace(namespace string, resources map[string][]ResourceInfo, opts common.Opts) string {
 	var buf strings.Builder
 	table := tablewriter.NewWriter(&buf)
 	table.SetColWidth(60)
@@ -127,7 +128,7 @@ func formatOutputForNamespace(namespace string, resources map[string][]ResourceI
 	return fmt.Sprintf("Unused resources in namespace: %q\n%s\n", namespace, buf.String())
 }
 
-func formatOutputForResource(resource string, resources map[string][]ResourceInfo, opts Opts) string {
+func formatOutputForResource(resource string, resources map[string][]ResourceInfo, opts common.Opts) string {
 	if len(resources) == 0 {
 		if opts.Verbose {
 			return fmt.Sprintf("No unused %ss found\n", resource)
@@ -209,7 +210,7 @@ func getTableRowResourceInfo(index int, resourceType string, resource ResourceIn
 	return row
 }
 
-func FormatOutputAll(namespace string, allDiffs []ResourceDiff, opts Opts) string {
+func FormatOutputAll(namespace string, allDiffs []ResourceDiff, opts common.Opts) string {
 	var buf strings.Builder
 	table := tablewriter.NewWriter(&buf)
 	table.SetColWidth(60)

--- a/pkg/kor/formatter.go
+++ b/pkg/kor/formatter.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"sigs.k8s.io/yaml"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/utils"
 )
 

--- a/pkg/kor/formatter.go
+++ b/pkg/kor/formatter.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"sigs.k8s.io/yaml"
+
+	"github.com/yonahd/kor/pkg/utils"
 )
 
 type ResourceInfo struct {
@@ -28,7 +30,7 @@ func unusedResourceFormatter(outputFormat string, outputBuffer bytes.Buffer, opt
 		if opts.WebhookURL == "" || opts.Channel == "" || opts.Token != "" {
 			return outputBuffer.String(), nil
 		}
-		if err := SendToSlack(SlackMessage{}, opts, outputBuffer.String()); err != nil {
+		if err := utils.SendToSlack(utils.SlackMessage{}, opts, outputBuffer.String()); err != nil {
 			return "", fmt.Errorf("failed to send message to slack: %w", err)
 		}
 	case "json", "yaml":

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -12,6 +12,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -80,7 +80,7 @@ func processNamespaceHpas(clientset kubernetes.Interface, namespace string, filt
 	return unusedHpas, nil
 }
 
-func GetUnusedHpas(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedHpas(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceHpas(clientset, namespace, filterOpts)

--- a/pkg/kor/hpas_test.go
+++ b/pkg/kor/hpas_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/hpas_test.go
+++ b/pkg/kor/hpas_test.go
@@ -83,7 +83,7 @@ func TestExtractUnusedHpas(t *testing.T) {
 func TestGetUnusedHpasStructured(t *testing.T) {
 	clientset := createTestHpas(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/ingresses.go
+++ b/pkg/kor/ingresses.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/ingresses.go
+++ b/pkg/kor/ingresses.go
@@ -116,7 +116,7 @@ func processNamespaceIngresses(clientset kubernetes.Interface, namespace string,
 
 }
 
-func GetUnusedIngresses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedIngresses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceIngresses(clientset, namespace, filterOpts)

--- a/pkg/kor/ingresses_test.go
+++ b/pkg/kor/ingresses_test.go
@@ -81,7 +81,7 @@ func TestRetrieveUsedIngress(t *testing.T) {
 func TestGetUnusedIngressesStructured(t *testing.T) {
 	clientset := createTestIngresses(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/ingresses_test.go
+++ b/pkg/kor/ingresses_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -65,7 +66,7 @@ func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filt
 	return unusedJobNames, nil
 }
 
-func GetUnusedJobs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedJobs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceJobs(clientset, namespace, filterOpts)

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -6,13 +6,13 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/jobs_test.go
+++ b/pkg/kor/jobs_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 	"time"
@@ -112,7 +113,7 @@ func TestProcessNamespaceJobs(t *testing.T) {
 func TestGetUnusedJobsStructured(t *testing.T) {
 	clientset := createTestJobs(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/jobs_test.go
+++ b/pkg/kor/jobs_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -41,17 +41,6 @@ type Config struct {
 	// Add other configurations if needed
 }
 
-type Opts struct {
-	DeleteFlag    bool
-	NoInteractive bool
-	Verbose       bool
-	WebhookURL    string
-	Channel       string
-	Token         string
-	GroupBy       string
-	ShowReason    bool
-}
-
 func RemoveDuplicatesAndSort(slice []string) []string {
 	uniqueSet := make(map[string]bool)
 	for _, item := range slice {

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -96,7 +96,7 @@ func retrieveNamespaceDiffs(clientset kubernetes.Interface, namespace string, re
 	return allDiffs
 }
 
-func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resourceList := strings.Split(resourceNames, ",")
 	namespaces := filterOpts.Namespaces(clientset)
 	resources := make(map[string]map[string][]ResourceInfo)

--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -53,7 +53,7 @@ func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace s
 	return unusedNetpols, nil
 }
 
-func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedNetworkPolicies(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 
 	for _, namespace := range filterOpts.Namespaces(clientset) {

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -100,7 +100,7 @@ func TestProcessNamespaceNetworkPolicies(t *testing.T) {
 func TestGetUnusedNetworkPolicies(t *testing.T) {
 	clientset := createTestNetworkPolicies(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/networkpolicies_test.go
+++ b/pkg/kor/networkpolicies_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -81,7 +81,7 @@ func processNamespacePdbs(clientset kubernetes.Interface, namespace string, filt
 	return unusedPdbs, nil
 }
 
-func GetUnusedPdbs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedPdbs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespacePdbs(clientset, namespace, filterOpts)

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -93,7 +93,7 @@ func TestProcessNamespacePdbs(t *testing.T) {
 func TestGetUnusedPdbsStructured(t *testing.T) {
 	clientset := createTestPdbs(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -43,7 +43,7 @@ func processNamespacePods(clientset kubernetes.Interface, namespace string, filt
 	return evictedPods, nil
 }
 
-func GetUnusedPods(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedPods(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespacePods(clientset, namespace, filterOpts)

--- a/pkg/kor/pods_test.go
+++ b/pkg/kor/pods_test.go
@@ -115,7 +115,7 @@ func TestProcessNamespacePods(t *testing.T) {
 func TestGetUnusedPodsStructured(t *testing.T) {
 	clientset := createTestPods(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/pods_test.go
+++ b/pkg/kor/pods_test.go
@@ -12,6 +12,7 @@ import (
 	fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +45,7 @@ func processPvs(clientset kubernetes.Interface, filterOpts *filters.Options) ([]
 
 }
 
-func GetUnusedPvs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedPvs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	diff, err := processPvs(clientset, filterOpts)
 	if err != nil {

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pv_test.go
+++ b/pkg/kor/pv_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pv_test.go
+++ b/pkg/kor/pv_test.go
@@ -61,7 +61,7 @@ func TestProcessPvs(t *testing.T) {
 func TestGetUnusedPvs(t *testing.T) {
 	clientset := createTestPvs(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,7 @@ func processNamespacePvcs(clientset kubernetes.Interface, namespace string, filt
 	return diff, nil
 }
 
-func GetUnusedPvcs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedPvcs(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespacePvcs(clientset, namespace, filterOpts)

--- a/pkg/kor/pvc_test.go
+++ b/pkg/kor/pvc_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/pvc_test.go
+++ b/pkg/kor/pvc_test.go
@@ -99,7 +99,7 @@ func TestProcessNamespacePvcs(t *testing.T) {
 func TestGetUnusedPvcsStructured(t *testing.T) {
 	clientset := createTestPvcs(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 	return unusedReplicaSetNames, nil
 }
 
-func GetUnusedReplicaSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedReplicaSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceReplicaSets(clientset, namespace, filterOpts)

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/yonahd/kor/pkg/common"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -57,7 +57,7 @@ func createTestReplicaSets(t *testing.T) *fake.Clientset {
 func TestProcessNamespaceReplicaSets(t *testing.T) {
 	clientset := createTestReplicaSets(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -101,7 +101,7 @@ func processNamespaceRoles(clientset kubernetes.Interface, namespace string, fil
 	return diff, nil
 }
 
-func GetUnusedRoles(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedRoles(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceRoles(clientset, namespace, filterOpts)

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/roles_test.go
+++ b/pkg/kor/roles_test.go
@@ -109,7 +109,7 @@ func TestProcessNamespaceRoles(t *testing.T) {
 func TestGetUnusedRolesStructured(t *testing.T) {
 	clientset := createTestRoles(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/roles_test.go
+++ b/pkg/kor/roles_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -13,6 +13,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -195,7 +195,7 @@ func processNamespaceSecret(clientset kubernetes.Interface, namespace string, fi
 
 }
 
-func GetUnusedSecrets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedSecrets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceSecret(clientset, namespace, filterOpts)

--- a/pkg/kor/secrets_test.go
+++ b/pkg/kor/secrets_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 
@@ -276,7 +277,7 @@ func TestProcessNamespaceSecret(t *testing.T) {
 func TestGetUnusedSecretsStructured(t *testing.T) {
 	clientset := createTestSecrets(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -163,7 +163,7 @@ func processNamespaceSA(clientset kubernetes.Interface, namespace string, filter
 	return unusedServiceAccounts, nil
 }
 
-func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedServiceAccounts(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceSA(clientset, namespace, filterOpts)

--- a/pkg/kor/serviceaccounts_test.go
+++ b/pkg/kor/serviceaccounts_test.go
@@ -3,7 +3,6 @@ package kor
 import (
 	"context"
 	"encoding/json"
-	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/serviceaccounts_test.go
+++ b/pkg/kor/serviceaccounts_test.go
@@ -3,6 +3,7 @@ package kor
 import (
 	"context"
 	"encoding/json"
+	"github.com/yonahd/kor/pkg/common"
 	"reflect"
 	"testing"
 
@@ -184,7 +185,7 @@ func TestGetUnusedServiceAccountsStructured(t *testing.T) {
 		t.Fatalf("Error creating fake %s: %v", "clusterRoleBinding", err)
 	}
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -59,7 +59,7 @@ func processNamespaceServices(clientset kubernetes.Interface, namespace string, 
 	return endpointsWithoutSubsets, nil
 }
 
-func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedServices(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 
 	for _, namespace := range filterOpts.Namespaces(clientset) {

--- a/pkg/kor/services_test.go
+++ b/pkg/kor/services_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/services_test.go
+++ b/pkg/kor/services_test.go
@@ -74,7 +74,7 @@ func TestGetEndpointsWithoutSubsets(t *testing.T) {
 func TestGetUnusedServicesStructured(t *testing.T) {
 	clientset := createTestServices(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -43,7 +43,7 @@ func processNamespaceStatefulSets(clientset kubernetes.Interface, namespace stri
 	return statefulSetsWithoutReplicas, nil
 }
 
-func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedStatefulSets(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	for _, namespace := range filterOpts.Namespaces(clientset) {
 		diff, err := processNamespaceStatefulSets(clientset, namespace, filterOpts)

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/statefulsets_test.go
+++ b/pkg/kor/statefulsets_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/statefulsets_test.go
+++ b/pkg/kor/statefulsets_test.go
@@ -74,7 +74,7 @@ func TestProcessNamespaceStatefulSets(t *testing.T) {
 func TestGetUnusedStatefulSetsStructured(t *testing.T) {
 	clientset := createTestStatefulSets(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -98,7 +98,7 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 	return unusedStorageClasses, nil
 }
 
-func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts Opts) (string, error) {
+func GetUnusedStorageClasses(filterOpts *filters.Options, clientset kubernetes.Interface, outputFormat string, opts common.Opts) (string, error) {
 	resources := make(map[string]map[string][]ResourceInfo)
 	diff, err := processStorageClasses(clientset, filterOpts)
 	if err != nil {

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/storageclasses_test.go
+++ b/pkg/kor/storageclasses_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/yonahd/kor/pkg/common"
 	"github.com/yonahd/kor/pkg/filters"
 )
 

--- a/pkg/kor/storageclasses_test.go
+++ b/pkg/kor/storageclasses_test.go
@@ -69,7 +69,7 @@ func TestProcessStorageClasses(t *testing.T) {
 func TestGetUnusedStorageClassesStructured(t *testing.T) {
 	clientset := createTestStorageClass(t)
 
-	opts := Opts{
+	opts := common.Opts{
 		WebhookURL:    "",
 		Channel:       "",
 		Token:         "",

--- a/pkg/utils/slack.go
+++ b/pkg/utils/slack.go
@@ -9,20 +9,22 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/yonahd/kor/pkg/kor"
 )
 
 type SendMessageToSlack interface {
-	SendToSlack(opts Opts, outputBuffer string) error
+	SendToSlack(opts kor.Opts, outputBuffer string) error
 }
 
 type SlackMessage struct {
 }
 
-func SendToSlack(sm SendMessageToSlack, opts Opts, outputBuffer string) error {
+func SendToSlack(sm SendMessageToSlack, opts kor.Opts, outputBuffer string) error {
 	return sm.SendToSlack(opts, outputBuffer)
 }
 
-func (sm SlackMessage) SendToSlack(opts Opts, outputBuffer string) error {
+func (sm SlackMessage) SendToSlack(opts kor.Opts, outputBuffer string) error {
 	if opts.WebhookURL != "" {
 		payload := []byte(`{"text": "` + outputBuffer + `"}`)
 		_, err := http.Post(opts.WebhookURL, "application/json", bytes.NewBuffer(payload))

--- a/pkg/utils/slack.go
+++ b/pkg/utils/slack.go
@@ -1,4 +1,4 @@
-package kor
+package utils
 
 import (
 	"bytes"

--- a/pkg/utils/slack.go
+++ b/pkg/utils/slack.go
@@ -10,21 +10,21 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/yonahd/kor/pkg/kor"
+	"github.com/yonahd/kor/pkg/common"
 )
 
 type SendMessageToSlack interface {
-	SendToSlack(opts kor.Opts, outputBuffer string) error
+	SendToSlack(opts common.Opts, outputBuffer string) error
 }
 
 type SlackMessage struct {
 }
 
-func SendToSlack(sm SendMessageToSlack, opts kor.Opts, outputBuffer string) error {
+func SendToSlack(sm SendMessageToSlack, opts common.Opts, outputBuffer string) error {
 	return sm.SendToSlack(opts, outputBuffer)
 }
 
-func (sm SlackMessage) SendToSlack(opts kor.Opts, outputBuffer string) error {
+func (sm SlackMessage) SendToSlack(opts common.Opts, outputBuffer string) error {
 	if opts.WebhookURL != "" {
 		payload := []byte(`{"text": "` + outputBuffer + `"}`)
 		_, err := http.Post(opts.WebhookURL, "application/json", bytes.NewBuffer(payload))

--- a/pkg/utils/slack_test.go
+++ b/pkg/utils/slack_test.go
@@ -6,25 +6,27 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/yonahd/kor/pkg/common"
 )
 
 type SendToSlackTestCase struct {
 	Name         string
-	Opts         Opts
+	Opts         common.Opts
 	OutputBuffer string
 }
 
 var testCases = []SendToSlackTestCase{
 	{
 		Name: "Test using WebhookURL",
-		Opts: Opts{
+		Opts: common.Opts{
 			WebhookURL: "slack.webhookurl.com",
 		},
 		OutputBuffer: "Test message",
 	},
 	{
 		Name: "Test using Channel and Token",
-		Opts: Opts{
+		Opts: common.Opts{
 			Channel: "your_channel",
 			Token:   "your_token",
 		},
@@ -32,7 +34,7 @@ var testCases = []SendToSlackTestCase{
 	},
 	{
 		Name:         "Test with empty Opts",
-		Opts:         Opts{},
+		Opts:         common.Opts{},
 		OutputBuffer: "Test message",
 	},
 }

--- a/pkg/utils/slack_test.go
+++ b/pkg/utils/slack_test.go
@@ -1,4 +1,4 @@
-package kor
+package utils
 
 import (
 	"bytes"


### PR DESCRIPTION

## What this PR does / why we need it?

This organizes the code in a better fashion moving the slack out of the core functionality directory

## PR Checklist

[x] This PR move the slack related code to utils


