### PR TITLE
fix: Multi output grouping by namespace

### DIFF
--- a/pkg/kor/multi.go
+++ b/pkg/kor/multi.go
@@ -103,6 +103,10 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 	resources := make(map[string]map[string][]ResourceInfo)
 	var err error
 
+	if opts.GroupBy == "namespace" {
+		resources[""] = make(map[string][]ResourceInfo)
+	}
+
 	noNamespaceDiff, resourceList := retrieveNoNamespaceDiff(clientset, apiExtClient, dynamicClient, resourceList, filterOpts)
 	if len(noNamespaceDiff) != 0 {
 		for _, diff := range noNamespaceDiff {
@@ -114,7 +118,6 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 				}
 				switch opts.GroupBy {
 				case "namespace":
-					resources[""] = make(map[string][]ResourceInfo)
 					resources[""][diff.resourceType] = diff.diff
 				case "resource":
 					appendResources(resources, diff.resourceType, "", diff.diff)
@@ -125,6 +128,10 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 
 	for _, namespace := range namespaces {
 		allDiffs := retrieveNamespaceDiffs(clientset, namespace, resourceList, filterOpts)
+		if opts.GroupBy == "namespace" {
+			resources[namespace] = make(map[string][]ResourceInfo)
+		}
+
 		for _, diff := range allDiffs {
 			if opts.DeleteFlag {
 				if diff.diff, err = DeleteResource(diff.diff, clientset, namespace, diff.resourceType, opts.NoInteractive); err != nil {
@@ -133,7 +140,6 @@ func GetUnusedMulti(resourceNames string, filterOpts *filters.Options, clientset
 			}
 			switch opts.GroupBy {
 			case "namespace":
-				resources[namespace] = make(map[string][]ResourceInfo)
 				resources[namespace][diff.resourceType] = diff.diff
 			case "resource":
 				appendResources(resources, diff.resourceType, namespace, diff.diff)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR fixes output overriding when using multi mode and grouping by namespace (default!).
Assuming multiple unused resource types exist, only the last in the list will be displayed.

Regardless to the misfortunate output:
- Grouping by resource works as expected for all resources
- Deletion works as expected for all resources

<details><summary>Example</summary>

```console
$ kor sa,cm -n kor --group-by=resource
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused ServiceAccounts:
+---+-----------+---------------+
| # | NAMESPACE | RESOURCE NAME |
+---+-----------+---------------+
| 1 | kor       | test          |
+---+-----------+---------------+

Unused ConfigMaps:
+---+-----------+---------------+
| # | NAMESPACE | RESOURCE NAME |
+---+-----------+---------------+
| 1 | kor       | test          |
+---+-----------+---------------+
```
</details>

<details><summary>Before fix</summary>

```console
$ kor sa,cm -n kor --group-by=namespace
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused resources in namespace: "kor"
+---+---------------+---------------+
| # | RESOURCE TYPE | RESOURCE NAME |
+---+---------------+---------------+
| 1 | ConfigMap     | test          |
+---+---------------+---------------+
```
</details>

<details><summary>After fix</summary>

```console
$ kor sa,cm -n kor --group-by=namespace
kor version: vdev

  _  _____  ____
 | |/ / _ \|  _ \
 | ' / | | | |_) |
 | . \ |_| |  _ <
 |_|\_\___/|_| \_\

Unused resources in namespace: "kor"
+---+----------------+---------------+
| # | RESOURCE TYPE  | RESOURCE NAME |
+---+----------------+---------------+
| 1 | ServiceAccount | test          |
| 2 | ConfigMap      | test          |
+---+----------------+---------------+
```
</details>

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes #348 

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
The root cause relies in the diff loop, and is outsourced to the namespace loop in case that's the requested output mode.