### PR TITLE
Adding option for podAnnotations on the deployment level 

### DIFF
--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -31,6 +31,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | prometheusExporter.args[0] | string | `"exporter"` |  |
 | prometheusExporter.command[0] | string | `"kor"` |  |
 | prometheusExporter.deployment.affinity | object | `{}` |  |
+| prometheusExporter.deployment.podAnnotations | object | `{}` |  |
 | prometheusExporter.deployment.image.repository | string | `"yonahdissen/kor"` |  |
 | prometheusExporter.deployment.image.tag | string | `"latest"` |  |
 | prometheusExporter.deployment.imagePullPolicy | string | `"Always"` |  |

--- a/charts/kor/templates/deployment.yaml
+++ b/charts/kor/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       app: {{ .Values.prometheusExporter.name }}
   template:
     metadata:
+      {{- with .Values.prometheusExporter.deployment.podAnnotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "kor.labels" . | nindent 8 }}
         app: {{ .Values.prometheusExporter.name }}

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -30,6 +30,9 @@ prometheusExporter:
     image:
       repository: yonahdissen/kor
       tag: latest
+    ## @param podAnnotations Annotations for Solr pods
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    podAnnotations: {}
     restartPolicy: Always
     imagePullPolicy: Always
     imagePullSecrets: []


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?

Currently the project support integration with Prometheus out of the box. To allow other provider such Datadog to collect metric we need to provide podAnnotation field [Datadog annotations integration](https://docs.datadoghq.com/containers/kubernetes/prometheus/?tab=kubernetesadv2)

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [x] This PR includes tests for new/existing code
- [x] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes [XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
