### PR TITLE
Add support for setting kubecontext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ kor
 !kor/
 *.swp
 hack/exceptions
+vendor

--- a/cmd/kor/all.go
+++ b/cmd/kor/all.go
@@ -14,9 +14,9 @@ var allCmd = &cobra.Command{
 	Short: "Gets unused resources",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
-		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
-		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
+		apiExtClient := kor.GetAPIExtensionsClient(kubeConfig)
+		dynamicClient := kor.GetDynamicClient(kubeConfig)
 
 		if response, err := kor.GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/clusterroles.go
+++ b/cmd/kor/clusterroles.go
@@ -15,7 +15,7 @@ var clusterRoleCmd = &cobra.Command{
 	Short:   "Gets unused cluster roles",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedClusterRoles(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/configmaps.go
+++ b/cmd/kor/configmaps.go
@@ -15,7 +15,7 @@ var configmapCmd = &cobra.Command{
 	Short:   "Gets unused configmaps",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 		if response, err := kor.GetUnusedConfigmaps(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)
 		} else {

--- a/cmd/kor/crds.go
+++ b/cmd/kor/crds.go
@@ -15,8 +15,8 @@ var crdCmd = &cobra.Command{
 	Short:   "Gets unused crds",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
-		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		apiExtClient := kor.GetAPIExtensionsClient(kubeConfig)
+		dynamicClient := kor.GetDynamicClient(kubeConfig)
 		if response, err := kor.GetUnusedCrds(filterOptions, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
 			fmt.Println(err)
 		} else {

--- a/cmd/kor/daemonsets.go
+++ b/cmd/kor/daemonsets.go
@@ -15,7 +15,7 @@ var dsCmd = &cobra.Command{
 	Short:   "Gets unused daemonSets",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedDaemonSets(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/deployments.go
+++ b/cmd/kor/deployments.go
@@ -15,7 +15,7 @@ var deployCmd = &cobra.Command{
 	Short:   "Gets unused deployments",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 		if response, err := kor.GetUnusedDeployments(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)
 		} else {

--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -13,9 +13,9 @@ var exporterCmd = &cobra.Command{
 	Short: "start prometheus exporter",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
-		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
-		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
+		apiExtClient := kor.GetAPIExtensionsClient(kubeConfig)
+		dynamicClient := kor.GetDynamicClient(kubeConfig)
 
 		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList)
 

--- a/cmd/kor/finalizers.go
+++ b/cmd/kor/finalizers.go
@@ -14,8 +14,8 @@ var finalizerCmd = &cobra.Command{
 	Short:   "Gets resources waiting for finalizers to delete",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
-		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
+		dynamicClient := kor.GetDynamicClient(kubeConfig)
 
 		if response, err := kor.GetUnusedfinalizers(filterOptions, clientset, dynamicClient, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/hpas.go
+++ b/cmd/kor/hpas.go
@@ -15,7 +15,7 @@ var hpaCmd = &cobra.Command{
 	Short:   "Gets unused hpas",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedHpas(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/ingresses.go
+++ b/cmd/kor/ingresses.go
@@ -15,7 +15,7 @@ var ingressCmd = &cobra.Command{
 	Short:   "Gets unused ingresses",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedIngresses(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/jobs.go
+++ b/cmd/kor/jobs.go
@@ -15,7 +15,7 @@ var jobCmd = &cobra.Command{
 	Short:   "Gets unused jobs",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedJobs(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/networkpolicies.go
+++ b/cmd/kor/networkpolicies.go
@@ -15,7 +15,7 @@ var netpolCmd = &cobra.Command{
 	Short:   "Gets unused networkpolicies",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 		if response, err := kor.GetUnusedNetworkPolicies(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)
 		} else {

--- a/cmd/kor/pdbs.go
+++ b/cmd/kor/pdbs.go
@@ -15,7 +15,7 @@ var pdbCmd = &cobra.Command{
 	Short:   "Gets unused pdbs",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedPdbs(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/pods.go
+++ b/cmd/kor/pods.go
@@ -15,7 +15,7 @@ var podCmd = &cobra.Command{
 	Short:   "Gets unused pods",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedPods(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/pv.go
+++ b/cmd/kor/pv.go
@@ -15,7 +15,7 @@ var pvCmd = &cobra.Command{
 	Short:   "Gets unused pvs",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedPvs(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/pvc.go
+++ b/cmd/kor/pvc.go
@@ -15,7 +15,7 @@ var pvcCmd = &cobra.Command{
 	Short:   "Gets unused pvcs",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedPvcs(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/replicasets.go
+++ b/cmd/kor/replicasets.go
@@ -15,7 +15,7 @@ var replicaSetCmd = &cobra.Command{
 	Short:   "Gets unused replicaSets",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedReplicaSets(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/rolebindings.go
+++ b/cmd/kor/rolebindings.go
@@ -15,7 +15,7 @@ var roleBindingCmd = &cobra.Command{
 	Short:   "Gets unused role bindings",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedRoleBindings(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/roles.go
+++ b/cmd/kor/roles.go
@@ -15,7 +15,7 @@ var roleCmd = &cobra.Command{
 	Short:   "Gets unused roles",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedRoles(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -31,9 +31,9 @@ var rootCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		resourceNames := args[0]
-		clientset := kor.GetKubeClient(kubeconfig)
-		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
-		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
+		apiExtClient := kor.GetAPIExtensionsClient(kubeConfig)
+		dynamicClient := kor.GetDynamicClient(kubeConfig)
 
 		if response, err := kor.GetUnusedMulti(resourceNames, filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
 			fmt.Println(err)
@@ -46,13 +46,15 @@ var rootCmd = &cobra.Command{
 
 var (
 	outputFormat  string
-	kubeconfig    string
+	kubeConfig    string
+	kubeContext   string
 	opts          common.Opts
 	filterOptions = &filters.Options{}
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "Path to kubeconfig file (optional)")
+	rootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "Path to kubeConfig file (optional)")
+	rootCmd.PersistentFlags().StringVarP(&kubeContext, "kubecontext", "c", "", "kubectl context to be used (optional)")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json or yaml)")
 	rootCmd.PersistentFlags().StringVar(&opts.WebhookURL, "slack-webhook-url", "", "Slack webhook URL to send notifications to")
 	rootCmd.PersistentFlags().StringVar(&opts.Channel, "slack-channel", "", "Slack channel to send notifications to. --slack-channel requires --slack-auth-token to be set.")

--- a/cmd/kor/secrets.go
+++ b/cmd/kor/secrets.go
@@ -15,7 +15,7 @@ var secretCmd = &cobra.Command{
 	Short:   "Gets unused secrets",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedSecrets(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/serviceaccounts.go
+++ b/cmd/kor/serviceaccounts.go
@@ -15,7 +15,7 @@ var serviceAccountCmd = &cobra.Command{
 	Short:   "Gets unused service accounts",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedServiceAccounts(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/services.go
+++ b/cmd/kor/services.go
@@ -15,7 +15,7 @@ var serviceCmd = &cobra.Command{
 	Short:   "Gets unused services",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedServices(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/statefulsets.go
+++ b/cmd/kor/statefulsets.go
@@ -15,7 +15,7 @@ var stsCmd = &cobra.Command{
 	Short:   "Gets unused statefulSets",
 	Args:    cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedStatefulSets(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/cmd/kor/storageclasses.go
+++ b/cmd/kor/storageclasses.go
@@ -15,7 +15,7 @@ var scCmd = &cobra.Command{
 	Short:   "Gets unused storageClasses",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientset := kor.GetKubeClient(kubeconfig)
+		clientset := kor.GetKubeClient(kubeConfig, kubeContext)
 
 		if response, err := kor.GetUnusedStorageClasses(filterOptions, clientset, outputFormat, opts); err != nil {
 			fmt.Println(err)

--- a/pkg/kor/kor_test.go
+++ b/pkg/kor/kor_test.go
@@ -99,7 +99,7 @@ func TestGetKubeClientFromEnvVar(t *testing.T) {
 	defer os.Setenv("KUBECONFIG", originalKCEnv)
 	os.Setenv("KUBECONFIG", configFile.Name())
 
-	kcs := GetKubeClient("")
+	kcs := GetKubeClient("", "")
 	if kcs == nil {
 		t.Errorf("Expected valid clientSet")
 	}
@@ -125,7 +125,7 @@ func TestGetKubeClientFromInput(t *testing.T) {
 		os.Setenv("KUBERNETES_SERVICE_PORT", oldKubeServicePort)
 	}()
 
-	kcs := GetKubeClient(configFile.Name())
+	kcs := GetKubeClient(configFile.Name(), "")
 	if kcs == nil {
 		t.Errorf("Expected valid clientSet")
 	}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
"In the current version, the `GetKubeClient` function is designed to operate with an externally set context. 
When using a `kube-config` containing multiple cluster configurations, the context must be set outside this utility. 
This PR allows passing the `kube-context` directly, similar to how it’s specified when using tools like `kubectl` or `helm`."

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes [XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
