### PR TITLE
refactor: Use new filter framework

### DIFF
--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -36,7 +36,13 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 	}
 
 	for _, crd := range crds.Items {
-		if pass := filters.KorLabelFilter(&crd, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&crd).Run(filterOpts); pass {
+			continue
+		}
+
+		if crd.Labels["kor/used"] == "false" {
+			reason := "Marked with unused label"
+			unusedCRDs = append(unusedCRDs, ResourceInfo{Name: crd.Name, Reason: reason})
 			continue
 		}
 

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -38,6 +38,12 @@ func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filt
 			continue
 		}
 
+		if job.Labels["kor/used"] == "false" {
+			reason := "Marked with unused label"
+			unusedJobNames = append(unusedJobNames, ResourceInfo{Name: job.Name, Reason: reason})
+			continue
+		}
+
 		exceptionFound, err := isResourceException(job.Name, job.Namespace, config.ExceptionJobs)
 		if err != nil {
 			return nil, err

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -24,7 +24,7 @@ func processNamespacePods(clientset kubernetes.Interface, namespace string, filt
 	var evictedPods []ResourceInfo
 
 	for _, pod := range podsList.Items {
-		if pass := filters.KorLabelFilter(&pod, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&pod).Run(filterOpts); pass {
 			continue
 		}
 

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -24,7 +24,7 @@ func processPvs(clientset kubernetes.Interface, filterOpts *filters.Options) ([]
 	var unusedPvs []ResourceInfo
 
 	for _, pv := range pvs.Items {
-		if pass := filters.KorLabelFilter(&pv, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&pv).Run(filterOpts); pass {
 			continue
 		}
 

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -42,7 +42,7 @@ func processNamespacePvcs(clientset kubernetes.Interface, namespace string, filt
 	var unusedPvcNames []string
 	pvcNames := make([]string, 0, len(pvcs.Items))
 	for _, pvc := range pvcs.Items {
-		if pass := filters.KorLabelFilter(&pvc, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&pvc).Run(filterOpts); pass {
 			continue
 		}
 

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -27,6 +27,12 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 			continue
 		}
 
+		if replicaSet.Labels["kor/used"] == "false" {
+			reason := "Marked with unused label"
+			unusedReplicaSetNames = append(unusedReplicaSetNames, ResourceInfo{Name: replicaSet.Name, Reason: reason})
+			continue
+		}
+
 		// if the replicaSet is specified 0 replica and current available & ready & fullyLabeled replica count is all 0, think the replicaSet is completed
 		if *replicaSet.Spec.Replicas == 0 && replicaSet.Status.AvailableReplicas == 0 && replicaSet.Status.ReadyReplicas == 0 && replicaSet.Status.FullyLabeledReplicas == 0 {
 			reason := "ReplicaSet is not in use"

--- a/pkg/kor/rolebindings.go
+++ b/pkg/kor/rolebindings.go
@@ -85,6 +85,12 @@ func processNamespaceRoleBindings(clientset kubernetes.Interface, namespace stri
 			continue
 		}
 
+		if rb.Labels["kor/used"] == "false" {
+			reason := "Marked with unused label"
+			unusedRoleBindingNames = append(unusedRoleBindingNames, ResourceInfo{Name: rb.Name, Reason: reason})
+			continue
+		}
+
 		if exceptionFound, err := isResourceException(rb.Name, rb.Namespace, config.ExceptionRoleBindings); err != nil {
 			return nil, err
 		} else if exceptionFound {

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -53,9 +53,10 @@ func retrieveRoleNames(clientset kubernetes.Interface, namespace string, filterO
 	var unusedRoleNames []string
 	names := make([]string, 0, len(roles.Items))
 	for _, role := range roles.Items {
-		if pass := filters.KorLabelFilter(&role, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&role).Run(filterOpts); pass {
 			continue
 		}
+
 		if role.Labels["kor/used"] == "false" {
 			unusedRoleNames = append(unusedRoleNames, role.Name)
 			continue

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -66,7 +66,7 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 	storageClassNames := make([]string, 0, len(scs.Items))
 
 	for _, sc := range scs.Items {
-		if pass := filters.KorLabelFilter(&sc, &filters.Options{}); pass {
+		if pass, _ := filter.SetObject(&sc).Run(filterOpts); pass {
 			continue
 		}
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
This PR refactors multiple resources that still used the old filtering method, resulting in filters not being applied upon them.
In addition, not all resources supported the `kor/used=false` exclusion. 

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [X] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes #384

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
