### PR TITLE
feat: Added --namespaced flag to filter namespaced/non-namespaced resources

### DIFF
--- a/charts/kor/Chart.yaml
+++ b/charts/kor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kor
 description: A Kubernetes Helm Chart to discover orphaned resources using kor
 type: application
-version: 0.1.18
-appVersion: "0.5.9"
+version: 0.1.19
+appVersion: "0.6.0"
 maintainers:
   - name: "yonahd"
     url: "https://github.com/yonahd/kor"

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -22,7 +22,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | cronJob.image.repository | string | `"yonahdissen/kor"` |  |
 | cronJob.image.tag | string | `"latest"` |  |
 | cronJob.name | string | `"kor"` |  |
-| cronJob.namespaced | string | `nil` |  |
+| cronJob.namespaced | string | `nil` | Set true/false to explicitly return namespaced/non-namespaced resources |
 | cronJob.restartPolicy | string | `"OnFailure"` |  |
 | cronJob.schedule | string | `"0 1 * * 1"` |  |
 | cronJob.slackAuthToken | string | `""` |  |
@@ -46,7 +46,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | prometheusExporter.enabled | bool | `true` |  |
 | prometheusExporter.exporterInterval | string | `""` |  |
 | prometheusExporter.name | string | `"kor-exporter"` |  |
-| prometheusExporter.namespaced | string | `nil` |  |
+| prometheusExporter.namespaced | string | `nil` | Set true/false to explicitly return namespaced/non-namespaced resources |
 | prometheusExporter.service.port | int | `8080` |  |
 | prometheusExporter.service.type | string | `"ClusterIP"` |  |
 | prometheusExporter.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -22,7 +22,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | cronJob.image.repository | string | `"yonahdissen/kor"` |  |
 | cronJob.image.tag | string | `"latest"` |  |
 | cronJob.name | string | `"kor"` |  |
-| cronJob.namespaced | string | `""` |  |
+| cronJob.namespaced | string | `nil` |  |
 | cronJob.restartPolicy | string | `"OnFailure"` |  |
 | cronJob.schedule | string | `"0 1 * * 1"` |  |
 | cronJob.slackAuthToken | string | `""` |  |
@@ -46,7 +46,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | prometheusExporter.enabled | bool | `true` |  |
 | prometheusExporter.exporterInterval | string | `""` |  |
 | prometheusExporter.name | string | `"kor-exporter"` |  |
-| prometheusExporter.namespaced | string | `""` |  |
+| prometheusExporter.namespaced | string | `nil` |  |
 | prometheusExporter.service.port | int | `8080` |  |
 | prometheusExporter.service.type | string | `"ClusterIP"` |  |
 | prometheusExporter.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/kor/README.md
+++ b/charts/kor/README.md
@@ -1,6 +1,6 @@
 # kor
 
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.9](https://img.shields.io/badge/AppVersion-0.5.9-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 A Kubernetes Helm Chart to discover orphaned resources using kor
 
@@ -22,6 +22,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | cronJob.image.repository | string | `"yonahdissen/kor"` |  |
 | cronJob.image.tag | string | `"latest"` |  |
 | cronJob.name | string | `"kor"` |  |
+| cronJob.namespaced | string | `""` |  |
 | cronJob.restartPolicy | string | `"OnFailure"` |  |
 | cronJob.schedule | string | `"0 1 * * 1"` |  |
 | cronJob.slackAuthToken | string | `""` |  |
@@ -45,6 +46,7 @@ A Kubernetes Helm Chart to discover orphaned resources using kor
 | prometheusExporter.enabled | bool | `true` |  |
 | prometheusExporter.exporterInterval | string | `""` |  |
 | prometheusExporter.name | string | `"kor-exporter"` |  |
+| prometheusExporter.namespaced | string | `""` |  |
 | prometheusExporter.service.port | int | `8080` |  |
 | prometheusExporter.service.type | string | `"ClusterIP"` |  |
 | prometheusExporter.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/kor/templates/cronjob.yaml
+++ b/charts/kor/templates/cronjob.yaml
@@ -24,6 +24,9 @@ spec:
                 {{- toYaml .Values.cronJob.command | nindent 16 }}
               args:
                 {{- toYaml .Values.cronJob.args | nindent 16 }}
+              {{- if .Values.cronJob.namespaced }}
+                - --namespaced={{ .Values.cronJob.namespaced }}
+              {{- end}}
               {{- if .Values.cronJob.slackWebhookUrl }}
                 - '--slack-webhook-url'
                 - "${SLACK_WEBHOOK_URL}"

--- a/charts/kor/templates/cronjob.yaml
+++ b/charts/kor/templates/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
                 {{- toYaml .Values.cronJob.command | nindent 16 }}
               args:
                 {{- toYaml .Values.cronJob.args | nindent 16 }}
-              {{- if .Values.cronJob.namespaced }}
+              {{- if ne .Values.cronJob.namespaced nil }}
                 - --namespaced={{ .Values.cronJob.namespaced }}
               {{- end}}
               {{- if .Values.cronJob.slackWebhookUrl }}

--- a/charts/kor/templates/deployment.yaml
+++ b/charts/kor/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- toYaml .Values.prometheusExporter.command | nindent 12 }}
           args:
             {{- toYaml .Values.prometheusExporter.args | nindent 12 }}
+          {{- if .Values.prometheusExporter.namespaced }}
+            - --namespaced={{ .Values.prometheusExporter.namespaced }}
+          {{- end}}
           ports:
           - containerPort: 8080
             name: http

--- a/charts/kor/templates/deployment.yaml
+++ b/charts/kor/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml .Values.prometheusExporter.command | nindent 12 }}
           args:
             {{- toYaml .Values.prometheusExporter.args | nindent 12 }}
-          {{- if .Values.prometheusExporter.namespaced }}
+          {{- if ne .Values.prometheusExporter.namespaced nil}}
             - --namespaced={{ .Values.prometheusExporter.namespaced }}
           {{- end}}
           ports:

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -10,6 +10,7 @@ cronJob:
     - kor
   args:
     - all
+  namespaced: "" # Set to true/false to return explicitly namespaced/non-namespaced resources
   slackWebhookUrl: ""
   slackChannel: ""
   slackAuthToken: ""
@@ -26,6 +27,7 @@ prometheusExporter:
     - kor
   args:
     - exporter
+  namespaced: "" # Set to true/false to return explicitly namespaced/non-namespaced resources
   deployment:
     image:
       repository: yonahdissen/kor

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -10,7 +10,7 @@ cronJob:
     - kor
   args:
     - all
-  namespaced: "" # Set true/false to explicitly return namespaced/non-namespaced resources
+  namespaced: null # Set true/false to explicitly return namespaced/non-namespaced resources
   slackWebhookUrl: ""
   slackChannel: ""
   slackAuthToken: ""
@@ -27,7 +27,7 @@ prometheusExporter:
     - kor
   args:
     - exporter
-  namespaced: "" # Set true/false to explicitly return namespaced/non-namespaced resources
+  namespaced: null # Set true/false to explicitly return namespaced/non-namespaced resources
   deployment:
     image:
       repository: yonahdissen/kor

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -10,7 +10,8 @@ cronJob:
     - kor
   args:
     - all
-  namespaced: null # Set true/false to explicitly return namespaced/non-namespaced resources
+  # -- Set true/false to explicitly return namespaced/non-namespaced resources
+  namespaced: null
   slackWebhookUrl: ""
   slackChannel: ""
   slackAuthToken: ""
@@ -27,7 +28,8 @@ prometheusExporter:
     - kor
   args:
     - exporter
-  namespaced: null # Set true/false to explicitly return namespaced/non-namespaced resources
+  # -- Set true/false to explicitly return namespaced/non-namespaced resources
+  namespaced: null
   deployment:
     image:
       repository: yonahdissen/kor

--- a/charts/kor/values.yaml
+++ b/charts/kor/values.yaml
@@ -10,7 +10,7 @@ cronJob:
     - kor
   args:
     - all
-  namespaced: "" # Set to true/false to return explicitly namespaced/non-namespaced resources
+  namespaced: "" # Set true/false to explicitly return namespaced/non-namespaced resources
   slackWebhookUrl: ""
   slackChannel: ""
   slackAuthToken: ""
@@ -27,7 +27,7 @@ prometheusExporter:
     - kor
   args:
     - exporter
-  namespaced: "" # Set to true/false to return explicitly namespaced/non-namespaced resources
+  namespaced: "" # Set true/false to explicitly return namespaced/non-namespaced resources
   deployment:
     image:
       repository: yonahdissen/kor

--- a/cmd/kor/all.go
+++ b/cmd/kor/all.go
@@ -17,8 +17,9 @@ var allCmd = &cobra.Command{
 		clientset := kor.GetKubeClient(kubeconfig)
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		scopeFlagUsed := cmd.Flags().Changed("namespaced")
 
-		if response, err := kor.GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
+		if response, err := kor.GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, scopeFlagUsed); err != nil {
 			fmt.Println(err)
 		} else {
 			utils.PrintLogo(outputFormat)
@@ -28,5 +29,6 @@ var allCmd = &cobra.Command{
 }
 
 func init() {
+	allCmd.PersistentFlags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
 	rootCmd.AddCommand(allCmd)
 }

--- a/cmd/kor/all.go
+++ b/cmd/kor/all.go
@@ -17,9 +17,9 @@ var allCmd = &cobra.Command{
 		clientset := kor.GetKubeClient(kubeconfig)
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
-		scopeFlagUsed := cmd.Flags().Changed("namespaced")
+		kor.SetNamespacedFlagState(cmd.Flags().Changed("namespaced"))
 
-		if response, err := kor.GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, scopeFlagUsed); err != nil {
+		if response, err := kor.GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts); err != nil {
 			fmt.Println(err)
 		} else {
 			utils.PrintLogo(outputFormat)

--- a/cmd/kor/all.go
+++ b/cmd/kor/all.go
@@ -29,6 +29,6 @@ var allCmd = &cobra.Command{
 }
 
 func init() {
-	allCmd.PersistentFlags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
+	allCmd.Flags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
 	rootCmd.AddCommand(allCmd)
 }

--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -16,9 +16,9 @@ var exporterCmd = &cobra.Command{
 		clientset := kor.GetKubeClient(kubeconfig)
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
-		isScopeSet := cmd.Flags().Changed("namespaced")
-
-		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList, isScopeSet)
+		kor.SetNamespacedFlagState(cmd.Flags().Changed("namespaced"))
+		
+		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList)
 
 	},
 }

--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -17,7 +17,6 @@ var exporterCmd = &cobra.Command{
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
 		kor.SetNamespacedFlagState(cmd.Flags().Changed("namespaced"))
-		
 		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList)
 
 	},

--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -16,13 +16,15 @@ var exporterCmd = &cobra.Command{
 		clientset := kor.GetKubeClient(kubeconfig)
 		apiExtClient := kor.GetAPIExtensionsClient(kubeconfig)
 		dynamicClient := kor.GetDynamicClient(kubeconfig)
+		isScopeSet := cmd.Flags().Changed("namespaced")
 
-		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList)
+		kor.Exporter(filterOptions, clientset, apiExtClient, dynamicClient, "json", opts, resourceList, isScopeSet)
 
 	},
 }
 
 func init() {
 	exporterCmd.Flags().StringSliceVarP(&resourceList, "resources", "r", nil, "Comma-separated list of resources to monitor (e.g., deployment,service)")
+	exporterCmd.Flags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
 	rootCmd.AddCommand(exporterCmd)
 }

--- a/pkg/common/params.go
+++ b/pkg/common/params.go
@@ -9,4 +9,5 @@ type Opts struct {
 	Token         string
 	GroupBy       string
 	ShowReason    bool
+	Namespaced    bool
 }

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -14,6 +14,8 @@ import (
 	"github.com/yonahd/kor/pkg/filters"
 )
 
+var NamespacedFlagUsed bool
+
 type GetUnusedResourceJSONResponse struct {
 	ResourceType string              `json:"resourceType"`
 	Namespaces   map[string][]string `json:"namespaces"`
@@ -377,7 +379,15 @@ func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes
 	return unusedAllNonNamespaced, nil
 }
 
-func GetUnusedAllScopes(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
+func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
+	if NamespacedFlagUsed {
+		if opts.Namespaced {
+			return GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
+		} else {	
+			return GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)	
+		}
+	} 
+
 	unusedAllNamespaced, err := GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
@@ -425,14 +435,6 @@ func GetUnusedAllScopes(filterOpts *filters.Options, clientset kubernetes.Interf
 	}
 }
 
-func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, scopeFlagUsed bool) (string, error) {
-	if scopeFlagUsed {
-		if opts.Namespaced {
-			return GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
-		} else {	
-			return GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)	
-		}
-	}
-
-	return GetUnusedAllScopes(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+func SetNamespacedFlagState(isFlagUsed bool) {
+	NamespacedFlagUsed = isFlagUsed
 }

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -383,10 +383,9 @@ func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, a
 	if NamespacedFlagUsed {
 		if opts.Namespaced {
 			return GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
-		} else {	
-			return GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)	
 		}
-	} 
+		return GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+	}
 
 	unusedAllNamespaced, err := GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
 	if err != nil {

--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -377,7 +377,7 @@ func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes
 	return unusedAllNonNamespaced, nil
 }
 
-func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
+func GetUnusedAllScopes(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts) (string, error) {
 	unusedAllNamespaced, err := GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
@@ -423,4 +423,16 @@ func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, a
 
 		return string(jsonResponse), nil
 	}
+}
+
+func GetUnusedAll(filterOpts *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, scopeFlagUsed bool) (string, error) {
+	if scopeFlagUsed {
+		if opts.Namespaced {
+			return GetUnusedAllNamespaced(filterOpts, clientset, outputFormat, opts)
+		} else {	
+			return GetUnusedAllNonNamespaced(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)	
+		}
+	}
+
+	return GetUnusedAllScopes(filterOpts, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 }

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -34,16 +34,16 @@ func init() {
 }
 
 // TODO: add option to change port / url !?
-func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) {
+func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
 	http.Handle("/metrics", promhttp.Handler())
 	fmt.Println("Server listening on :8080")
-	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList, isScopeSet) // Start exporting metrics in the background
+	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList) // Start exporting metrics in the background
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		fmt.Println(err)
 	}
 }
 
-func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) {
+func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
 	exporterInterval := os.Getenv("EXPORTER_INTERVAL")
 	if exporterInterval == "" {
 		exporterInterval = "10"
@@ -56,7 +56,7 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 
 	for {
 		fmt.Println("collecting unused resources")
-		if korOutput, err := getUnusedResources(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList, isScopeSet); err != nil {
+		if korOutput, err := getUnusedResources(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		} else {
@@ -80,9 +80,9 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 	}
 }
 
-func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) (string, error) {
+func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) (string, error) {
 	if len(resourceList) == 0 || (len(resourceList) == 1 && resourceList[0] == "all") {
-		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, isScopeSet)
+		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 	}
 	return GetUnusedMulti(strings.Join(resourceList, ","), filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 

--- a/pkg/kor/exporter.go
+++ b/pkg/kor/exporter.go
@@ -34,16 +34,16 @@ func init() {
 }
 
 // TODO: add option to change port / url !?
-func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
+func Exporter(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) {
 	http.Handle("/metrics", promhttp.Handler())
 	fmt.Println("Server listening on :8080")
-	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList) // Start exporting metrics in the background
+	go exportMetrics(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList, isScopeSet) // Start exporting metrics in the background
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		fmt.Println(err)
 	}
 }
 
-func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) {
+func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) {
 	exporterInterval := os.Getenv("EXPORTER_INTERVAL")
 	if exporterInterval == "" {
 		exporterInterval = "10"
@@ -56,7 +56,7 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 
 	for {
 		fmt.Println("collecting unused resources")
-		if korOutput, err := getUnusedResources(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList); err != nil {
+		if korOutput, err := getUnusedResources(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, resourceList, isScopeSet); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		} else {
@@ -80,9 +80,9 @@ func exportMetrics(filterOptions *filters.Options, clientset kubernetes.Interfac
 	}
 }
 
-func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string) (string, error) {
+func getUnusedResources(filterOptions *filters.Options, clientset kubernetes.Interface, apiExtClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, outputFormat string, opts common.Opts, resourceList []string, isScopeSet bool) (string, error) {
 	if len(resourceList) == 0 || (len(resourceList) == 1 && resourceList[0] == "all") {
-		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
+		return GetUnusedAll(filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts, isScopeSet)
 	}
 	return GetUnusedMulti(strings.Join(resourceList, ","), filterOptions, clientset, apiExtClient, dynamicClient, outputFormat, opts)
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?
Inspired by `kubectl api-resources --namespaced` flag, this PR adds the new flag to both `kor all` & `kor exporter` commands, allowing users to explicitly discover namespaced/non-namespaced resources.

Not using the flag == discovering both types of resources.
The change is also introduced in the Helm chart.

<details><summary>Examples</summary>

```
$ kor all -o yaml --group-by=resource
ConfigMap:
  default:
  - test
ServiceAccount:
  default:
  - test
ClusterRole:
  "":
  - test

$ kor all -o yaml --group-by=resource --namespaced
ConfigMap:
  default:
  - test
ServiceAccount:
  default:
  - test

$ kor all -o yaml --group-by=resource --namespaced=false
ClusterRole:
  "":
  - test
```
</details>

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes [XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
