### PR TITLE
fix VolumeAttachment pluralisation in all.go

### DIFF
--- a/pkg/kor/all.go
+++ b/pkg/kor/all.go
@@ -363,13 +363,13 @@ func GetUnusedAllNonNamespaced(filterOpts *filters.Options, clientset kubernetes
 		resources[""]["Pv"] = getUnusedPvs(clientset, filterOpts).diff
 		resources[""]["ClusterRole"] = getUnusedClusterRoles(clientset, filterOpts).diff
 		resources[""]["StorageClass"] = getUnusedStorageClasses(clientset, filterOpts).diff
-		resources[""]["VolumeAttachments"] = getUnusedVolumeAttachments(clientset, filterOpts).diff
+		resources[""]["VolumeAttachment"] = getUnusedVolumeAttachments(clientset, filterOpts).diff
 	case "resource":
 		appendResources(resources, "Crd", "", getUnusedCrds(apiExtClient, dynamicClient, filterOpts).diff)
 		appendResources(resources, "Pv", "", getUnusedPvs(clientset, filterOpts).diff)
 		appendResources(resources, "ClusterRole", "", getUnusedClusterRoles(clientset, filterOpts).diff)
 		appendResources(resources, "StorageClass", "", getUnusedStorageClasses(clientset, filterOpts).diff)
-		appendResources(resources, "VolumeAttachments", "", getUnusedVolumeAttachments(clientset, filterOpts).diff)
+		appendResources(resources, "VolumeAttachment", "", getUnusedVolumeAttachments(clientset, filterOpts).diff)
 
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it?
Corrects the pluralization of `VolumeAttachment` in all.go.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

