### PR TITLE
Feat: Get plural resource kinds from K8s

### DIFF
--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -46,16 +46,23 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	outputFormat  string
-	kubeconfig    string
-	opts          common.Opts
-	filterOptions = &filters.Options{}
+	outputFormat     string
+	kubeconfig       string
+	opts             common.Opts
+	filterOptions    = &filters.Options{}
+	resourceKindList map[string]kor.ResourceKind
 )
 
 func init() {
 	initFlags()
 	initViper()
+	initKindsList()
 	addFilterOptionsFlag(rootCmd, filterOptions)
+}
+
+func initKindsList() {
+	clientset := kor.GetKubeClient(kubeconfig)
+	resourceKindList, _ = kor.GetResourceKinds(clientset)
 }
 
 func initFlags() {

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -46,11 +46,10 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	outputFormat     string
-	kubeconfig       string
-	opts             common.Opts
-	filterOptions    = &filters.Options{}
-	resourceKindList map[string]kor.ResourceKind
+	outputFormat  string
+	kubeconfig    string
+	opts          common.Opts
+	filterOptions = &filters.Options{}
 )
 
 func init() {
@@ -62,7 +61,7 @@ func init() {
 
 func initKindsList() {
 	clientset := kor.GetKubeClient(kubeconfig)
-	resourceKindList, _ = kor.GetResourceKinds(clientset)
+	kor.ResourceKindList, _ = kor.GetResourceKinds(clientset)
 }
 
 func initFlags() {

--- a/pkg/kor/formatter.go
+++ b/pkg/kor/formatter.go
@@ -131,7 +131,7 @@ func formatOutputForNamespace(namespace string, resources map[string][]ResourceI
 func formatOutputForResource(resource string, resources map[string][]ResourceInfo, opts common.Opts) string {
 	if len(resources) == 0 {
 		if opts.Verbose {
-			return fmt.Sprintf("No unused %ss found\n", resource)
+			return fmt.Sprintf("No unused %s found\n", ResourceKindList[strings.ToLower(resource)].Plural)
 		}
 		return ""
 	}
@@ -151,7 +151,7 @@ func formatOutputForResource(resource string, resources map[string][]ResourceInf
 		}
 	}
 	table.Render()
-	return fmt.Sprintf("Unused %ss:\n%s\n", resource, buf.String())
+	return fmt.Sprintf("Unused %s:\n%s\n", ResourceKindList[strings.ToLower(resource)].Plural, buf.String())
 }
 
 func appendResources(resources map[string]map[string][]ResourceInfo, resourceType, namespace string, diff []ResourceInfo) {

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+var ResourceKindList map[string]ResourceKind
+
 type ExceptionResource struct {
 	Namespace    string
 	ResourceName string

--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -25,6 +25,10 @@ type IncludeExcludeLists struct {
 	IncludeListStr string
 	ExcludeListStr string
 }
+type ResourceKind struct {
+	Plural     string
+	ShortNames []string
+}
 
 type Config struct {
 	ExceptionClusterRoles    []ExceptionResource `json:"exceptionClusterRoles"`
@@ -204,4 +208,35 @@ func convertNamesToPresenseMap(names []string, _ []string, err error) (map[strin
 	}
 
 	return namesMap, nil
+}
+
+func GetResourceKinds(clientset kubernetes.Interface) (map[string]ResourceKind, error) {
+	resourceTypes, err := clientset.Discovery().ServerPreferredResources()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching server resources: %v", err)
+	}
+
+	kinds := make(map[string]ResourceKind)
+
+	for _, list := range resourceTypes {
+		if list == nil {
+			continue // Skip nil lists (can happen if some APIs are unavailable)
+		}
+
+		for _, resource := range list.APIResources {
+			singularName := resource.SingularName
+			if singularName == "" {
+				singularName = resource.Name
+			}
+
+			resourceKind := ResourceKind{
+				Plural:     resource.Name,
+				ShortNames: resource.ShortNames,
+			}
+
+			kinds[singularName] = resourceKind
+		}
+	}
+
+	return kinds, nil
 }

--- a/pkg/kor/multi_test.go
+++ b/pkg/kor/multi_test.go
@@ -17,6 +17,21 @@ import (
 func createTestMultiResources(t *testing.T) *fake.Clientset {
 	clientset := fake.NewClientset()
 
+	ResourceKindList = map[string]ResourceKind{
+		"configmap": {
+			Plural:     "configmaps",
+			ShortNames: []string{"cm"},
+		},
+		"poddisruptionbudget": {
+			Plural:     "poddisruptionbudgets",
+			ShortNames: []string{"pdb"},
+		},
+		"deployment": {
+			Plural:     "deployments",
+			ShortNames: []string{"deploy"},
+		},
+	}
+
 	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
 	}, v1.CreateOptions{})


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?

This uses the K8s API to get plural resource kinds instead of relying on hard-coding an `s` after them.

For example, instead of printing `storageclasss`, which is wrong, now we print `storageclasses`.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->