### PR TITLE
fix: support multiple kubeconfig files from KUBECONFIG env

### DIFF
--- a/pkg/kor/kor.go
+++ b/pkg/kor/kor.go
@@ -65,15 +65,16 @@ func GetConfig(kubeconfig string) (*rest.Config, error) {
 		return rest.InClusterConfig()
 	}
 
-	if kubeconfig == "" {
-		if configEnv := os.Getenv("KUBECONFIG"); configEnv != "" {
-			kubeconfig = configEnv
-		} else {
-			kubeconfig = GetKubeConfigPath()
-		}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
 	}
 
-	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	return kubeConfig.ClientConfig()
 }
 
 func GetKubeClient(kubeconfig string) *kubernetes.Clientset {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->
Fixes a bug where kor failed to parse multiple kubeconfig files passed via the `KUBECONFIG` environment variable.

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

### Before:
kor failed with an error if `KUBECONFIG` included a colon-separated list (e.g. `~/.kube/config:/path/to/second.yaml`)

### After:
kor uses the official method, which properly supports multiple kubeconfig files.
## What this PR does / why we need it?

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [x] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes [XX-XX]
#404 
<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
