### PR TITLE
fix: skip kubeconfig initialization for utility and completion commands

### DIFF
--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -30,6 +30,14 @@ var rootCmd = &cobra.Command{
 	Long: `kor is a CLI to discover unused Kubernetes resources
 	kor can currently discover unused configmaps and secrets`,
 	Args: cobra.MinimumNArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if shouldSkipKubeInitialization(cmd) {
+			return nil
+		}
+
+		initKindsList()
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		resourceNames := args[0]
 		clientset := kor.GetKubeClient(kubeconfig)
@@ -55,13 +63,15 @@ var (
 func init() {
 	initFlags()
 	initViper()
-	initKindsList()
 	addFilterOptionsFlag(rootCmd, filterOptions)
 }
 
 func initKindsList() {
-	clientset := kor.GetKubeClient(kubeconfig)
-	kor.ResourceKindList, _ = kor.GetResourceKinds(clientset)
+	// Only initialize if not already done
+	if kor.ResourceKindList == nil {
+		clientset := kor.GetKubeClient(kubeconfig)
+		kor.ResourceKindList, _ = kor.GetResourceKinds(clientset)
+	}
 }
 
 func initFlags() {
@@ -122,4 +132,26 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringVar(&opts.IncludeLabels, "include-labels", opts.IncludeLabels, "Selector to filter in, Example: --include-labels key1=value1 (currently supports one label)")
 	cmd.PersistentFlags().StringSliceVarP(&opts.ExcludeNamespaces, "exclude-namespaces", "e", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored")
 	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored")
+}
+
+// shouldSkipKubeInitialization determines if a command should skip kubeconfig initialization.
+func shouldSkipKubeInitialization(cmd *cobra.Command) bool {
+	cmdName := cmd.Name()
+
+	if cmdName == "version" || cmdName == "help" || cmdName == "completion" {
+		return true
+	}
+
+	if cmd.Parent() != nil && cmd.Parent().Name() == "completion" {
+		return true
+	}
+
+	shellCompletionCommands := []string{"bash", "zsh", "fish", "powershell"}
+	for _, shellCmd := range shellCompletionCommands {
+		if cmdName == shellCmd {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION

## What this PR does / why we need it?

Update init process to skip kubeconfig initialization, which was added in https://github.com/yonahd/kor/pull/445

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->


## Notes for your reviewers

seeing some completion generation issue when building 0.6.2 release, https://github.com/Homebrew/homebrew-core/pull/227766