### PR TITLE
feat: add flags to skip owner-referenced resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --older-than string            The minimum age of the resources to be considered unused. This flag cannot be used together with newer-than flag. Example: --older-than=1h2m
   -o, --output string                Output format (table, json or yaml) (default "table")
       --show-reason                  Print reason resource is considered unused
-      --skip-cronjob-jobs            Skip jobs that are created by cronjobs
-      --skip-deployment-replicasets  Skip replicasets that are owned by deployments or statefulsets
+      --ignore-owner-references      Skip resources that have ownerReferences set (for all resource types)
       --slack-auth-token string      Slack auth token to send notifications to, requires --slack-channel to be set
       --slack-channel string         Slack channel to send notifications to, requires --slack-auth-token to be set
       --slack-webhook-url string     Slack webhook URL to send notifications to

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Kor provides various subcommands to identify and list unused resources. The avai
       --older-than string            The minimum age of the resources to be considered unused. This flag cannot be used together with newer-than flag. Example: --older-than=1h2m
   -o, --output string                Output format (table, json or yaml) (default "table")
       --show-reason                  Print reason resource is considered unused
+      --skip-cronjob-jobs            Skip jobs that are created by cronjobs
+      --skip-deployment-replicasets  Skip replicasets that are owned by deployments or statefulsets
       --slack-auth-token string      Slack auth token to send notifications to, requires --slack-channel to be set
       --slack-channel string         Slack channel to send notifications to, requires --slack-auth-token to be set
       --slack-webhook-url string     Slack webhook URL to send notifications to

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -122,4 +122,6 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringVar(&opts.IncludeLabels, "include-labels", opts.IncludeLabels, "Selector to filter in, Example: --include-labels key1=value1 (currently supports one label)")
 	cmd.PersistentFlags().StringSliceVarP(&opts.ExcludeNamespaces, "exclude-namespaces", "e", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored")
 	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored")
+	cmd.PersistentFlags().BoolVar(&opts.SkipDeploymentReplicaSets, "skip-deployment-replicasets", false, "Skip replicasets that are owned by deployments or statefulsets")
+	cmd.PersistentFlags().BoolVar(&opts.SkipCronJobJobs, "skip-cronjob-jobs", false, "Skip jobs that are created by cronjobs")
 }

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -122,6 +122,5 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringVar(&opts.IncludeLabels, "include-labels", opts.IncludeLabels, "Selector to filter in, Example: --include-labels key1=value1 (currently supports one label)")
 	cmd.PersistentFlags().StringSliceVarP(&opts.ExcludeNamespaces, "exclude-namespaces", "e", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored")
 	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored")
-	cmd.PersistentFlags().BoolVar(&opts.SkipDeploymentReplicaSets, "skip-deployment-replicasets", false, "Skip replicasets that are owned by deployments or statefulsets")
-	cmd.PersistentFlags().BoolVar(&opts.SkipCronJobJobs, "skip-cronjob-jobs", false, "Skip jobs that are created by cronjobs")
+	cmd.PersistentFlags().BoolVar(&opts.IgnoreOwnerReferences, "ignore-owner-references", false, "Skip resources that have ownerReferences set (for all resource types)")
 }

--- a/pkg/filters/options.go
+++ b/pkg/filters/options.go
@@ -39,10 +39,8 @@ type Options struct {
 	ExcludeNamespaces []string
 	// IncludeNamespaces is a namespace selector to include resources in matching namespaces
 	IncludeNamespaces []string
-	// SkipDeploymentReplicaSets skips replicasets that are owned by deployments or statefulsets
-	SkipDeploymentReplicaSets bool
-	// SkipCronJobJobs skips jobs that are created by cronjobs
-	SkipCronJobJobs bool
+	// IgnoreOwnerReferences skips any resource that has ownerReferences set (for all resource types)
+	IgnoreOwnerReferences bool
 
 	namespace []string
 	once      sync.Once

--- a/pkg/filters/options.go
+++ b/pkg/filters/options.go
@@ -39,6 +39,10 @@ type Options struct {
 	ExcludeNamespaces []string
 	// IncludeNamespaces is a namespace selector to include resources in matching namespaces
 	IncludeNamespaces []string
+	// SkipDeploymentReplicaSets skips replicasets that are owned by deployments or statefulsets
+	SkipDeploymentReplicaSets bool
+	// SkipCronJobJobs skips jobs that are created by cronjobs
+	SkipCronJobJobs bool
 
 	namespace []string
 	once      sync.Once

--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -128,6 +128,9 @@ func retrieveClusterRoleNames(clientset kubernetes.Interface, filterOpts *filter
 	names := make([]string, 0, len(clusterRoles.Items))
 
 	for _, clusterRole := range clusterRoles.Items {
+		if filterOpts.IgnoreOwnerReferences && len(clusterRole.OwnerReferences) > 0 {
+			continue
+		}
 		if pass, _ := filter.SetObject(&clusterRole).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/configmaps.go
+++ b/pkg/kor/configmaps.go
@@ -93,6 +93,11 @@ func retrieveConfigMapNames(clientset kubernetes.Interface, namespace string, fi
 	names := make([]string, 0, len(configmaps.Items))
 
 	for _, configmap := range configmaps.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(configmap.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&configmap).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/crds.go
+++ b/pkg/kor/crds.go
@@ -36,6 +36,11 @@ func processCrds(apiExtClient apiextensionsclientset.Interface, dynamicClient dy
 	}
 
 	for _, crd := range crds.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(crd.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&crd).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/daemonsets.go
+++ b/pkg/kor/daemonsets.go
@@ -32,6 +32,11 @@ func processNamespaceDaemonSets(clientset kubernetes.Interface, namespace string
 	var daemonSetsWithoutReplicas []ResourceInfo
 
 	for _, daemonSet := range daemonSetsList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(daemonSet.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&daemonSet).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/daemonsets_test.go
+++ b/pkg/kor/daemonsets_test.go
@@ -63,6 +63,46 @@ func createTestDaemonSets(t *testing.T) *fake.Clientset {
 	return clientset
 }
 
+func createTestDaemonSetsWithOwnerReferences(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// DaemonSet with ownerReferences (should be ignored when --ignore-owner-references is true)
+	dsWithOwner := CreateTestDaemonSet(testNamespace, "test-ds-with-owner", AppLabels, &appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 0,
+	})
+	dsWithOwner.OwnerReferences = []v1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "test-deployment",
+			UID:        "test-uid",
+		},
+	}
+	_, err = clientset.AppsV1().DaemonSets(testNamespace).Create(context.TODO(), dsWithOwner, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake DaemonSet with ownerReferences: %v", err)
+	}
+
+	// DaemonSet without ownerReferences (should be included)
+	dsWithoutOwner := CreateTestDaemonSet(testNamespace, "test-ds-without-owner", AppLabels, &appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 0,
+	})
+	_, err = clientset.AppsV1().DaemonSets(testNamespace).Create(context.TODO(), dsWithoutOwner, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake DaemonSet without ownerReferences: %v", err)
+	}
+
+	return clientset
+}
+
 func TestProcessNamespaceDaemonSets(t *testing.T) {
 	clientset := createTestDaemonSets(t)
 
@@ -77,6 +117,36 @@ func TestProcessNamespaceDaemonSets(t *testing.T) {
 
 	if daemonSetsWithoutReplicas[0].Name != "test-ds1" && daemonSetsWithoutReplicas[1].Name != "test-ds4" {
 		t.Errorf("Expected 'test-ds1', 'test-ds4', got %s, %s", daemonSetsWithoutReplicas[0], daemonSetsWithoutReplicas[1])
+	}
+}
+
+func TestProcessNamespaceDaemonSetsWithOwnerReferences(t *testing.T) {
+	clientset := createTestDaemonSetsWithOwnerReferences(t)
+
+	// Test with --ignore-owner-references=false (default behavior)
+	daemonSetsWithoutReplicas, err := processNamespaceDaemonSets(clientset, testNamespace, &filters.Options{}, common.Opts{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should include both DaemonSets (with and without ownerReferences)
+	if len(daemonSetsWithoutReplicas) != 2 {
+		t.Errorf("Expected 2 DaemonSets without replicas, got %d", len(daemonSetsWithoutReplicas))
+	}
+
+	// Test with --ignore-owner-references=true
+	daemonSetsWithoutReplicas, err = processNamespaceDaemonSets(clientset, testNamespace, &filters.Options{IgnoreOwnerReferences: true}, common.Opts{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should only include DaemonSet without ownerReferences
+	if len(daemonSetsWithoutReplicas) != 1 {
+		t.Errorf("Expected 1 DaemonSet without replicas when ignoring ownerReferences, got %d", len(daemonSetsWithoutReplicas))
+	}
+
+	if daemonSetsWithoutReplicas[0].Name != "test-ds-without-owner" {
+		t.Errorf("Expected 'test-ds-without-owner', got %s", daemonSetsWithoutReplicas[0].Name)
 	}
 }
 
@@ -102,6 +172,42 @@ func TestGetUnusedDaemonSetsStructured(t *testing.T) {
 			"DaemonSet": {
 				"test-ds1",
 				"test-ds4",
+			},
+		},
+	}
+
+	var actualOutput map[string]map[string][]string
+	if err := json.Unmarshal([]byte(output), &actualOutput); err != nil {
+		t.Fatalf("Error unmarshaling actual output: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedOutput, actualOutput) {
+		t.Errorf("Expected output does not match actual output")
+	}
+}
+
+func TestGetUnusedDaemonSetsStructuredWithOwnerReferences(t *testing.T) {
+	clientset := createTestDaemonSetsWithOwnerReferences(t)
+
+	opts := common.Opts{
+		WebhookURL:    "",
+		Channel:       "",
+		Token:         "",
+		DeleteFlag:    false,
+		NoInteractive: true,
+		GroupBy:       "namespace",
+	}
+
+	// Test with --ignore-owner-references=true
+	output, err := GetUnusedDaemonSets(&filters.Options{IgnoreOwnerReferences: true}, clientset, "json", opts)
+	if err != nil {
+		t.Fatalf("Error calling GetUnusedDaemonSetsStructured: %v", err)
+	}
+
+	expectedOutput := map[string]map[string][]string{
+		testNamespace: {
+			"DaemonSet": {
+				"test-ds-without-owner",
 			},
 		},
 	}

--- a/pkg/kor/deployments.go
+++ b/pkg/kor/deployments.go
@@ -23,6 +23,11 @@ func processNamespaceDeployments(clientset kubernetes.Interface, namespace strin
 	var deploymentsWithoutReplicas []ResourceInfo
 
 	for _, deployment := range deploymentsList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(deployment.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&deployment).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/deployments_test.go
+++ b/pkg/kor/deployments_test.go
@@ -129,7 +129,7 @@ func TestFilterOwnerReferencedDeployments(t *testing.T) {
 			Name: "test-application",
 		},
 	}
-	
+
 	// Standalone Deployment
 	standaloneDeployment := CreateTestDeployment(testNamespace, "standalone-deployment", 0, AppLabels)
 

--- a/pkg/kor/deployments_test.go
+++ b/pkg/kor/deployments_test.go
@@ -108,6 +108,68 @@ func TestGetUnusedDeploymentsStructured(t *testing.T) {
 	}
 }
 
+func TestFilterOwnerReferencedDeployments(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// Create two deployments - one owned by another resource, one standalone
+	// Deployment owned by another resource
+	ownedDeployment := CreateTestDeployment(testNamespace, "owned-deployment", 0, AppLabels)
+	// Add owner reference to another resource
+	ownedDeployment.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Application",
+			Name: "test-application",
+		},
+	}
+	
+	// Standalone Deployment
+	standaloneDeployment := CreateTestDeployment(testNamespace, "standalone-deployment", 0, AppLabels)
+
+	_, err = clientset.AppsV1().Deployments(testNamespace).Create(context.TODO(), ownedDeployment, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake deployment: %v", err)
+	}
+
+	_, err = clientset.AppsV1().Deployments(testNamespace).Create(context.TODO(), standaloneDeployment, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake deployment: %v", err)
+	}
+
+	// Test without filter - should return both
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
+	unusedWithoutFilter, err := processNamespaceDeployments(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused deployments: %v", err)
+	}
+
+	if len(unusedWithoutFilter) != 2 {
+		t.Errorf("Expected 2 unused Deployment objects without filter, got %d", len(unusedWithoutFilter))
+	}
+
+	// Test with filter - should return only standalone
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
+	unusedWithFilter, err := processNamespaceDeployments(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused deployments: %v", err)
+	}
+
+	if len(unusedWithFilter) != 1 {
+		t.Errorf("Expected 1 unused Deployment object with filter, got %d", len(unusedWithFilter))
+	}
+
+	if unusedWithFilter[0].Name != "standalone-deployment" {
+		t.Errorf("Expected standalone-deployment to be unused, got %s", unusedWithFilter[0].Name)
+	}
+}
+
 func init() {
 	scheme.Scheme = runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme.Scheme)

--- a/pkg/kor/hpas.go
+++ b/pkg/kor/hpas.go
@@ -62,6 +62,11 @@ func processNamespaceHpas(clientset kubernetes.Interface, namespace string, filt
 			continue
 		}
 
+		// Skip if resource has owner references and ignore flag is set
+		if filterOpts.IgnoreOwnerReferences && len(hpa.OwnerReferences) > 0 {
+			continue
+		}
+
 		if hpa.Labels["kor/used"] == "false" {
 			unusedHpas = append(unusedHpas, ResourceInfo{Name: hpa.Name, Reason: "Marked with unused label"})
 			continue

--- a/pkg/kor/ingresses.go
+++ b/pkg/kor/ingresses.go
@@ -82,6 +82,11 @@ func retrieveIngressNames(clientset kubernetes.Interface, namespace string, filt
 			continue
 		}
 
+		// Skip if resource has owner references and ignore flag is set
+		if filterOpts.IgnoreOwnerReferences && len(ingress.OwnerReferences) > 0 {
+			continue
+		}
+
 		if ingress.Labels["kor/used"] == "false" {
 			unusedIngressNames = append(unusedIngressNames, ingress.Name)
 			continue

--- a/pkg/kor/ingresses_test.go
+++ b/pkg/kor/ingresses_test.go
@@ -62,6 +62,42 @@ func createTestIngresses(t *testing.T) *fake.Clientset {
 	return clientset
 }
 
+func createTestIngressesWithOwnerReferences(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// Ingress with ownerReferences (should be ignored when --ignore-owner-references is true)
+	ingressWithOwner := CreateTestIngress(testNamespace, "test-ingress-with-owner", "non-existing-service", "test-secret", AppLabels)
+	ingressWithOwner.OwnerReferences = []v1.OwnerReference{
+		{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "IngressClass",
+			Name:       "test-ingress-class",
+			UID:        "test-uid",
+		},
+	}
+	_, err = clientset.NetworkingV1().Ingresses(testNamespace).Create(context.TODO(), ingressWithOwner, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake Ingress with ownerReferences: %v", err)
+	}
+
+	// Ingress without ownerReferences (should be included)
+	ingressWithoutOwner := CreateTestIngress(testNamespace, "test-ingress-without-owner", "non-existing-service", "test-secret", AppLabels)
+	_, err = clientset.NetworkingV1().Ingresses(testNamespace).Create(context.TODO(), ingressWithoutOwner, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake Ingress without ownerReferences: %v", err)
+	}
+
+	return clientset
+}
+
 func TestRetrieveUsedIngress(t *testing.T) {
 	clientset := createTestIngresses(t)
 
@@ -76,6 +112,36 @@ func TestRetrieveUsedIngress(t *testing.T) {
 
 	if !contains(usedIngresses, "test-ingress-1") {
 		t.Error("Expected specific Ingress objects in the list")
+	}
+}
+
+func TestProcessNamespaceIngressesWithOwnerReferences(t *testing.T) {
+	clientset := createTestIngressesWithOwnerReferences(t)
+
+	// Test with --ignore-owner-references=false (default behavior)
+	unusedIngresses, err := processNamespaceIngresses(clientset, testNamespace, &filters.Options{}, common.Opts{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should include both Ingresses (with and without ownerReferences)
+	if len(unusedIngresses) != 2 {
+		t.Errorf("Expected 2 unused Ingresses, got %d", len(unusedIngresses))
+	}
+
+	// Test with --ignore-owner-references=true
+	unusedIngresses, err = processNamespaceIngresses(clientset, testNamespace, &filters.Options{IgnoreOwnerReferences: true}, common.Opts{})
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should only include Ingress without ownerReferences
+	if len(unusedIngresses) != 1 {
+		t.Errorf("Expected 1 unused Ingress when ignoring ownerReferences, got %d", len(unusedIngresses))
+	}
+
+	if unusedIngresses[0].Name != "test-ingress-without-owner" {
+		t.Errorf("Expected 'test-ingress-without-owner', got %s", unusedIngresses[0].Name)
 	}
 }
 
@@ -101,6 +167,42 @@ func TestGetUnusedIngressesStructured(t *testing.T) {
 			"Ingress": {
 				"test-ingress-2",
 				"test-ingress-4",
+			},
+		},
+	}
+
+	var actualOutput map[string]map[string][]string
+	if err := json.Unmarshal([]byte(output), &actualOutput); err != nil {
+		t.Fatalf("Error unmarshaling actual output: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedOutput, actualOutput) {
+		t.Errorf("Expected output does not match actual output")
+	}
+}
+
+func TestGetUnusedIngressesStructuredWithOwnerReferences(t *testing.T) {
+	clientset := createTestIngressesWithOwnerReferences(t)
+
+	opts := common.Opts{
+		WebhookURL:    "",
+		Channel:       "",
+		Token:         "",
+		DeleteFlag:    false,
+		NoInteractive: true,
+		GroupBy:       "namespace",
+	}
+
+	// Test with --ignore-owner-references=true
+	output, err := GetUnusedIngresses(&filters.Options{IgnoreOwnerReferences: true}, clientset, "json", opts)
+	if err != nil {
+		t.Fatalf("Error calling GetUnusedIngressesStructured: %v", err)
+	}
+
+	expectedOutput := map[string]map[string][]string{
+		testNamespace: {
+			"Ingress": {
+				"test-ingress-without-owner",
 			},
 		},
 	}

--- a/pkg/kor/jobs.go
+++ b/pkg/kor/jobs.go
@@ -53,6 +53,20 @@ func processNamespaceJobs(clientset kubernetes.Interface, namespace string, filt
 			continue
 		}
 
+		// Skip jobs owned by cronjobs if flag is set
+		if filterOpts.SkipCronJobJobs {
+			isOwnedByCronJob := false
+			for _, owner := range job.OwnerReferences {
+				if owner.Kind == "CronJob" {
+					isOwnedByCronJob = true
+					break
+				}
+			}
+			if isOwnedByCronJob {
+				continue
+			}
+		}
+
 		// if the job has completionTime and succeeded count greater than zero, think the job is completed
 		if job.Status.CompletionTime != nil && job.Status.Succeeded > 0 {
 			reason := "Job has completed"

--- a/pkg/kor/jobs_test.go
+++ b/pkg/kor/jobs_test.go
@@ -252,7 +252,7 @@ func TestFilterCronJobOwnedJobs(t *testing.T) {
 	}
 
 	// Test without filter - should return both (both are completed)
-	filterOptsNoSkip := &filters.Options{SkipCronJobJobs: false}
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
 	unusedWithoutFilter, err := processNamespaceJobs(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
 	if err != nil {
 		t.Fatalf("Error retrieving unused jobs: %v", err)
@@ -263,7 +263,7 @@ func TestFilterCronJobOwnedJobs(t *testing.T) {
 	}
 
 	// Test with filter - should return only standalone
-	filterOptsWithSkip := &filters.Options{SkipCronJobJobs: true}
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
 	unusedWithFilter, err := processNamespaceJobs(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
 	if err != nil {
 		t.Fatalf("Error retrieving unused jobs: %v", err)

--- a/pkg/kor/jobs_test.go
+++ b/pkg/kor/jobs_test.go
@@ -233,7 +233,7 @@ func TestFilterCronJobOwnedJobs(t *testing.T) {
 			Name: "test-cronjob",
 		},
 	}
-	
+
 	// Standalone Job (completed)
 	standaloneJob := CreateTestJob(testNamespace, "standalone-job", &batchv1.JobStatus{
 		Succeeded:      1,

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -129,6 +129,11 @@ func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace s
 			continue
 		}
 
+		// ownerReferences kontrolü
+		if filterOpts.IgnoreOwnerReferences && len(netpol.OwnerReferences) > 0 {
+			continue
+		}
+
 		if netpol.Labels["kor/used"] == "false" {
 			unusedNetpols = append(unusedNetpols, ResourceInfo{Name: netpol.Name, Reason: unusedLabelReason})
 			continue

--- a/pkg/kor/networkpolicies.go
+++ b/pkg/kor/networkpolicies.go
@@ -129,7 +129,7 @@ func processNamespaceNetworkPolicies(clientset kubernetes.Interface, namespace s
 			continue
 		}
 
-		// ownerReferences kontrolü
+		// Skip resources with ownerReferences if the general flag is set
 		if filterOpts.IgnoreOwnerReferences && len(netpol.OwnerReferences) > 0 {
 			continue
 		}

--- a/pkg/kor/pdbs.go
+++ b/pkg/kor/pdbs.go
@@ -33,6 +33,11 @@ func processNamespacePdbs(clientset kubernetes.Interface, namespace string, filt
 	}
 
 	for _, pdb := range pdbs.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(pdb.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&pdb).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -174,3 +174,65 @@ func TestGetUnusedPdbsStructured(t *testing.T) {
 		t.Errorf("Expected output does not match actual output")
 	}
 }
+
+func TestFilterOwnerReferencedPdbs(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// Create two PDBs - one owned by another resource, one standalone
+	// PDB owned by another resource
+	ownedPdb := CreateTestPdb(testNamespace, "owned-pdb", AppLabels, AppLabels)
+	// Add owner reference to another resource
+	ownedPdb.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Application",
+			Name: "test-application",
+		},
+	}
+	
+	// Standalone PDB
+	standalonePdb := CreateTestPdb(testNamespace, "standalone-pdb", AppLabels, AppLabels)
+
+	_, err = clientset.PolicyV1().PodDisruptionBudgets(testNamespace).Create(context.TODO(), ownedPdb, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake PDB: %v", err)
+	}
+
+	_, err = clientset.PolicyV1().PodDisruptionBudgets(testNamespace).Create(context.TODO(), standalonePdb, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake PDB: %v", err)
+	}
+
+	// Test without filter - should return both
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
+	unusedWithoutFilter, err := processNamespacePdbs(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused PDBs: %v", err)
+	}
+
+	if len(unusedWithoutFilter) != 2 {
+		t.Errorf("Expected 2 unused PDB objects without filter, got %d", len(unusedWithoutFilter))
+	}
+
+	// Test with filter - should return only standalone
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
+	unusedWithFilter, err := processNamespacePdbs(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused PDBs: %v", err)
+	}
+
+	if len(unusedWithFilter) != 1 {
+		t.Errorf("Expected 1 unused PDB object with filter, got %d", len(unusedWithFilter))
+	}
+
+	if unusedWithFilter[0].Name != "standalone-pdb" {
+		t.Errorf("Expected standalone-pdb to be unused, got %s", unusedWithFilter[0].Name)
+	}
+}

--- a/pkg/kor/pdbs_test.go
+++ b/pkg/kor/pdbs_test.go
@@ -196,7 +196,7 @@ func TestFilterOwnerReferencedPdbs(t *testing.T) {
 			Name: "test-application",
 		},
 	}
-	
+
 	// Standalone PDB
 	standalonePdb := CreateTestPdb(testNamespace, "standalone-pdb", AppLabels, AppLabels)
 

--- a/pkg/kor/pods.go
+++ b/pkg/kor/pods.go
@@ -24,6 +24,11 @@ func processNamespacePods(clientset kubernetes.Interface, namespace string, filt
 	var evictedPods []ResourceInfo
 
 	for _, pod := range podsList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(pod.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&pod).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/pv.go
+++ b/pkg/kor/pv.go
@@ -24,6 +24,11 @@ func processPvs(clientset kubernetes.Interface, filterOpts *filters.Options) ([]
 	var unusedPvs []ResourceInfo
 
 	for _, pv := range pvs.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(pv.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&pv).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/pvc.go
+++ b/pkg/kor/pvc.go
@@ -47,6 +47,11 @@ func processNamespacePvcs(clientset kubernetes.Interface, namespace string, filt
 	var unusedPvcNames []string
 	pvcNames := make([]string, 0, len(pvcs.Items))
 	for _, pvc := range pvcs.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(pvc.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&pvc).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -33,18 +33,9 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 			continue
 		}
 
-		// Skip replicasets owned by deployments or statefulsets if flag is set
-		if filterOpts.SkipDeploymentReplicaSets {
-			isOwnedByDeploymentOrStatefulSet := false
-			for _, owner := range replicaSet.OwnerReferences {
-				if owner.Kind == "Deployment" || owner.Kind == "StatefulSet" {
-					isOwnedByDeploymentOrStatefulSet = true
-					break
-				}
-			}
-			if isOwnedByDeploymentOrStatefulSet {
-				continue
-			}
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(replicaSet.OwnerReferences) > 0 {
+			continue
 		}
 
 		// if the replicaSet is specified 0 replica and current available & ready & fullyLabeled replica count is all 0, think the replicaSet is completed

--- a/pkg/kor/replicaset.go
+++ b/pkg/kor/replicaset.go
@@ -33,6 +33,20 @@ func processNamespaceReplicaSets(clientset kubernetes.Interface, namespace strin
 			continue
 		}
 
+		// Skip replicasets owned by deployments or statefulsets if flag is set
+		if filterOpts.SkipDeploymentReplicaSets {
+			isOwnedByDeploymentOrStatefulSet := false
+			for _, owner := range replicaSet.OwnerReferences {
+				if owner.Kind == "Deployment" || owner.Kind == "StatefulSet" {
+					isOwnedByDeploymentOrStatefulSet = true
+					break
+				}
+			}
+			if isOwnedByDeploymentOrStatefulSet {
+				continue
+			}
+		}
+
 		// if the replicaSet is specified 0 replica and current available & ready & fullyLabeled replica count is all 0, think the replicaSet is completed
 		if *replicaSet.Spec.Replicas == 0 && replicaSet.Status.AvailableReplicas == 0 && replicaSet.Status.ReadyReplicas == 0 && replicaSet.Status.FullyLabeledReplicas == 0 {
 			reason := "ReplicaSet is not in use"

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -88,6 +88,87 @@ func TestProcessNamespaceReplicaSets(t *testing.T) {
 	}
 }
 
+func TestFilterDeploymentOwnedReplicaSets(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// Create a deployment
+	deployment := CreateTestDeployment(testNamespace, "test-deployment", 1, AppLabels)
+	_, err = clientset.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake deployment: %v", err)
+	}
+
+	// Create two replicasets - one owned by deployment, one standalone
+	var count int32 = 0
+	
+	// ReplicaSet owned by deployment
+	ownedRS := CreateTestReplicaSet(testNamespace, "owned-rs", &count, &appsv1.ReplicaSetStatus{
+		Replicas:             count,
+		AvailableReplicas:    count,
+		ReadyReplicas:        count,
+		FullyLabeledReplicas: count,
+	})
+	// Add owner reference to deployment
+	ownedRS.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "test-deployment",
+		},
+	}
+	
+	// Standalone ReplicaSet
+	standaloneRS := CreateTestReplicaSet(testNamespace, "standalone-rs", &count, &appsv1.ReplicaSetStatus{
+		Replicas:             count,
+		AvailableReplicas:    count,
+		ReadyReplicas:        count,
+		FullyLabeledReplicas: count,
+	})
+
+	_, err = clientset.AppsV1().ReplicaSets(testNamespace).Create(context.TODO(), ownedRS, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake replicaSet: %v", err)
+	}
+
+	_, err = clientset.AppsV1().ReplicaSets(testNamespace).Create(context.TODO(), standaloneRS, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake replicaSet: %v", err)
+	}
+
+	// Test without filter - should return both
+	filterOptsNoSkip := &filters.Options{SkipDeploymentReplicaSets: false}
+	unusedWithoutFilter, err := processNamespaceReplicaSets(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused replica sets: %v", err)
+	}
+
+	if len(unusedWithoutFilter) != 2 {
+		t.Errorf("Expected 2 unused ReplicaSet objects without filter, got %d", len(unusedWithoutFilter))
+	}
+
+	// Test with filter - should return only standalone
+	filterOptsWithSkip := &filters.Options{SkipDeploymentReplicaSets: true}
+	unusedWithFilter, err := processNamespaceReplicaSets(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused replica sets: %v", err)
+	}
+
+	if len(unusedWithFilter) != 1 {
+		t.Errorf("Expected 1 unused ReplicaSet object with filter, got %d", len(unusedWithFilter))
+	}
+
+	if unusedWithFilter[0].Name != "standalone-rs" {
+		t.Errorf("Expected standalone-rs to be unused, got %s", unusedWithFilter[0].Name)
+	}
+}
+
 func init() {
 	scheme.Scheme = runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme.Scheme)

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -143,7 +143,7 @@ func TestFilterDeploymentOwnedReplicaSets(t *testing.T) {
 	}
 
 	// Test without filter - should return both
-	filterOptsNoSkip := &filters.Options{SkipDeploymentReplicaSets: false}
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
 	unusedWithoutFilter, err := processNamespaceReplicaSets(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
 	if err != nil {
 		t.Fatalf("Error retrieving unused replica sets: %v", err)
@@ -154,7 +154,7 @@ func TestFilterDeploymentOwnedReplicaSets(t *testing.T) {
 	}
 
 	// Test with filter - should return only standalone
-	filterOptsWithSkip := &filters.Options{SkipDeploymentReplicaSets: true}
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
 	unusedWithFilter, err := processNamespaceReplicaSets(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
 	if err != nil {
 		t.Fatalf("Error retrieving unused replica sets: %v", err)

--- a/pkg/kor/replicaset_test.go
+++ b/pkg/kor/replicaset_test.go
@@ -108,7 +108,7 @@ func TestFilterDeploymentOwnedReplicaSets(t *testing.T) {
 
 	// Create two replicasets - one owned by deployment, one standalone
 	var count int32 = 0
-	
+
 	// ReplicaSet owned by deployment
 	ownedRS := CreateTestReplicaSet(testNamespace, "owned-rs", &count, &appsv1.ReplicaSetStatus{
 		Replicas:             count,
@@ -123,7 +123,7 @@ func TestFilterDeploymentOwnedReplicaSets(t *testing.T) {
 			Name: "test-deployment",
 		},
 	}
-	
+
 	// Standalone ReplicaSet
 	standaloneRS := CreateTestReplicaSet(testNamespace, "standalone-rs", &count, &appsv1.ReplicaSetStatus{
 		Replicas:             count,

--- a/pkg/kor/rolebindings.go
+++ b/pkg/kor/rolebindings.go
@@ -81,6 +81,11 @@ func processNamespaceRoleBindings(clientset kubernetes.Interface, namespace stri
 	var unusedRoleBindingNames []ResourceInfo
 
 	for _, rb := range roleBindingsList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(rb.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&rb).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/roles.go
+++ b/pkg/kor/roles.go
@@ -53,6 +53,9 @@ func retrieveRoleNames(clientset kubernetes.Interface, namespace string, filterO
 	var unusedRoleNames []string
 	names := make([]string, 0, len(roles.Items))
 	for _, role := range roles.Items {
+		if filterOpts.IgnoreOwnerReferences && len(role.OwnerReferences) > 0 {
+			continue
+		}
 		if pass, _ := filter.SetObject(&role).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/secrets.go
+++ b/pkg/kor/secrets.go
@@ -128,6 +128,11 @@ func retrieveSecretNames(clientset kubernetes.Interface, namespace string, filte
 	var unusedSecretNames []string
 	names := make([]string, 0, len(secrets.Items))
 	for _, secret := range secrets.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(secret.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&secret).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/serviceaccounts.go
+++ b/pkg/kor/serviceaccounts.go
@@ -111,6 +111,11 @@ func retrieveServiceAccountNames(clientset kubernetes.Interface, namespace strin
 			continue
 		}
 
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(serviceaccount.OwnerReferences) > 0 {
+			continue
+		}
+
 		if serviceaccount.Labels["kor/used"] == "false" {
 			unusedServiceAccountNames = append(unusedServiceAccountNames, serviceaccount.Name)
 			continue

--- a/pkg/kor/services.go
+++ b/pkg/kor/services.go
@@ -32,6 +32,11 @@ func processNamespaceServices(clientset kubernetes.Interface, namespace string, 
 	var endpointsWithoutSubsets []ResourceInfo
 
 	for _, endpoints := range endpointSlices.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(endpoints.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&endpoints).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/services_test.go
+++ b/pkg/kor/services_test.go
@@ -109,6 +109,128 @@ func TestGetUnusedServicesStructured(t *testing.T) {
 	}
 }
 
+func TestFilterOwnerReferencedServices(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	// Create two services - one owned by deployment, one standalone
+	// Service owned by deployment
+	ownedService := CreateTestService(testNamespace, "owned-service")
+	// Add owner reference to deployment
+	ownedService.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "test-deployment",
+		},
+	}
+	
+	// Standalone Service
+	standaloneService := CreateTestService(testNamespace, "standalone-service")
+
+	_, err = clientset.CoreV1().Services(testNamespace).Create(context.TODO(), ownedService, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake service: %v", err)
+	}
+
+	_, err = clientset.CoreV1().Services(testNamespace).Create(context.TODO(), standaloneService, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake service: %v", err)
+	}
+
+	// Create EndpointSlices for the services
+	// EndpointSlice for owned service (with endpoints)
+	ownedEndpointSlice := CreateTestEndpoint(testNamespace, "owned-service-endpoints", 1, AppLabels)
+	ownedEndpointSlice.Labels["kubernetes.io/service-name"] = "owned-service"
+	ownedEndpointSlice.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "test-deployment",
+		},
+	}
+
+	// EndpointSlice for standalone service (with endpoints)
+	standaloneEndpointSlice := CreateTestEndpoint(testNamespace, "standalone-service-endpoints", 1, AppLabels)
+	standaloneEndpointSlice.Labels["kubernetes.io/service-name"] = "standalone-service"
+
+	_, err = clientset.DiscoveryV1().EndpointSlices(testNamespace).Create(context.TODO(), ownedEndpointSlice, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake endpoint slice: %v", err)
+	}
+
+	_, err = clientset.DiscoveryV1().EndpointSlices(testNamespace).Create(context.TODO(), standaloneEndpointSlice, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake endpoint slice: %v", err)
+	}
+
+	// Test without filter - should return both
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
+	unusedWithoutFilter, err := processNamespaceServices(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused services: %v", err)
+	}
+
+	if len(unusedWithoutFilter) != 0 {
+		t.Errorf("Expected 0 unused Service objects without filter (both have endpoints), got %d", len(unusedWithoutFilter))
+	}
+
+	// Create EndpointSlices without endpoints to make them unused
+	// EndpointSlice for owned service (without endpoints)
+	ownedEndpointSliceNoEndpoints := CreateTestEndpoint(testNamespace, "owned-service-endpoints-empty", 0, AppLabels)
+	ownedEndpointSliceNoEndpoints.Labels["kubernetes.io/service-name"] = "owned-service"
+	ownedEndpointSliceNoEndpoints.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "test-deployment",
+		},
+	}
+
+	// EndpointSlice for standalone service (without endpoints)
+	standaloneEndpointSliceNoEndpoints := CreateTestEndpoint(testNamespace, "standalone-service-endpoints-empty", 0, AppLabels)
+	standaloneEndpointSliceNoEndpoints.Labels["kubernetes.io/service-name"] = "standalone-service"
+
+	_, err = clientset.DiscoveryV1().EndpointSlices(testNamespace).Create(context.TODO(), ownedEndpointSliceNoEndpoints, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake endpoint slice: %v", err)
+	}
+
+	_, err = clientset.DiscoveryV1().EndpointSlices(testNamespace).Create(context.TODO(), standaloneEndpointSliceNoEndpoints, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake endpoint slice: %v", err)
+	}
+
+	// Test without filter - should return both
+	unusedWithoutFilter2, err := processNamespaceServices(clientset, testNamespace, filterOptsNoSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused services: %v", err)
+	}
+
+	if len(unusedWithoutFilter2) != 2 {
+		t.Errorf("Expected 2 unused Service objects without filter, got %d", len(unusedWithoutFilter2))
+	}
+
+	// Test with filter - should return only standalone
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
+	unusedWithFilter, err := processNamespaceServices(clientset, testNamespace, filterOptsWithSkip, common.Opts{})
+	if err != nil {
+		t.Fatalf("Error retrieving unused services: %v", err)
+	}
+
+	if len(unusedWithFilter) != 1 {
+		t.Errorf("Expected 1 unused Service object with filter, got %d", len(unusedWithFilter))
+	}
+
+	if unusedWithFilter[0].Name != "standalone-service" {
+		t.Errorf("Expected standalone-service to be unused, got %s", unusedWithFilter[0].Name)
+	}
+}
+
 func init() {
 	scheme.Scheme = runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme.Scheme)

--- a/pkg/kor/services_test.go
+++ b/pkg/kor/services_test.go
@@ -130,7 +130,7 @@ func TestFilterOwnerReferencedServices(t *testing.T) {
 			Name: "test-deployment",
 		},
 	}
-	
+
 	// Standalone Service
 	standaloneService := CreateTestService(testNamespace, "standalone-service")
 

--- a/pkg/kor/statefulsets.go
+++ b/pkg/kor/statefulsets.go
@@ -23,6 +23,11 @@ func processNamespaceStatefulSets(clientset kubernetes.Interface, namespace stri
 	var statefulSetsWithoutReplicas []ResourceInfo
 
 	for _, statefulSet := range statefulSetsList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(statefulSet.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&statefulSet).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/storageclasses.go
+++ b/pkg/kor/storageclasses.go
@@ -66,6 +66,11 @@ func processStorageClasses(clientset kubernetes.Interface, filterOpts *filters.O
 	storageClassNames := make([]string, 0, len(scs.Items))
 
 	for _, sc := range scs.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(sc.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&sc).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/storageclasses_test.go
+++ b/pkg/kor/storageclasses_test.go
@@ -113,7 +113,7 @@ func TestFilterOwnerReferencedStorageClasses(t *testing.T) {
 			Name: "test-application",
 		},
 	}
-	
+
 	// Standalone StorageClass
 	standaloneSC := CreateTestStorageClass("standalone-sc", "kor.com")
 

--- a/pkg/kor/volumeattachments.go
+++ b/pkg/kor/volumeattachments.go
@@ -26,6 +26,11 @@ func processVolumeAttachments(clientset kubernetes.Interface, filterOpts *filter
 	var unusedVAtts []ResourceInfo
 
 	for _, va := range vaList.Items {
+		// Skip resources with ownerReferences if the general flag is set
+		if filterOpts.IgnoreOwnerReferences && len(va.OwnerReferences) > 0 {
+			continue
+		}
+
 		if pass, _ := filter.SetObject(&va).Run(filterOpts); pass {
 			continue
 		}

--- a/pkg/kor/volumeattachments_test.go
+++ b/pkg/kor/volumeattachments_test.go
@@ -100,3 +100,75 @@ func TestGetUnusedVolumeAttachments(t *testing.T) {
 		t.Errorf("Expected output %+v, but got %+v", expectedOutput, actualOutput)
 	}
 }
+
+func TestFilterOwnerReferencedVolumeAttachments(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	// Create a valid node
+	_, err := clientset.CoreV1().Nodes().Create(context.TODO(), CreateTestNode("node-1"), v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating node: %v", err)
+	}
+
+	// Create a valid PV
+	_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), CreateTestPv("pv-1", "", map[string]string{}, ""), v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating PV: %v", err)
+	}
+
+	// Create a valid CSIDriver
+	_, err = clientset.StorageV1().CSIDrivers().Create(context.TODO(), CreateTestCSIDriver("csi-driver-1"), v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating CSIDriver: %v", err)
+	}
+
+	// Create two VolumeAttachments - one owned by another resource, one standalone
+	// VolumeAttachment owned by another resource (with invalid PV to make it unused)
+	ownedVA := CreateTestVolumeAttachment("owned-va", "csi-driver-1", "node-1", "invalid-pv")
+	// Add owner reference to another resource
+	ownedVA.OwnerReferences = []v1.OwnerReference{
+		{
+			Kind: "Pod",
+			Name: "test-pod",
+		},
+	}
+	
+	// Standalone VolumeAttachment (with invalid PV to make it unused)
+	standaloneVA := CreateTestVolumeAttachment("standalone-va", "csi-driver-1", "node-1", "invalid-pv")
+
+	_, err = clientset.StorageV1().VolumeAttachments().Create(context.TODO(), ownedVA, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake VolumeAttachment: %v", err)
+	}
+
+	_, err = clientset.StorageV1().VolumeAttachments().Create(context.TODO(), standaloneVA, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating fake VolumeAttachment: %v", err)
+	}
+
+	// Test without filter - should return both
+	filterOptsNoSkip := &filters.Options{IgnoreOwnerReferences: false}
+	unusedWithoutFilter, err := processVolumeAttachments(clientset, filterOptsNoSkip)
+	if err != nil {
+		t.Fatalf("Error retrieving unused VolumeAttachments: %v", err)
+	}
+
+	if len(unusedWithoutFilter) != 2 {
+		t.Errorf("Expected 2 unused VolumeAttachment objects without filter, got %d", len(unusedWithoutFilter))
+	}
+
+	// Test with filter - should return only standalone
+	filterOptsWithSkip := &filters.Options{IgnoreOwnerReferences: true}
+	unusedWithFilter, err := processVolumeAttachments(clientset, filterOptsWithSkip)
+	if err != nil {
+		t.Fatalf("Error retrieving unused VolumeAttachments: %v", err)
+	}
+
+	if len(unusedWithFilter) != 1 {
+		t.Errorf("Expected 1 unused VolumeAttachment object with filter, got %d", len(unusedWithFilter))
+	}
+
+	if unusedWithFilter[0].Name != "standalone-va" {
+		t.Errorf("Expected standalone-va to be unused, got %s", unusedWithFilter[0].Name)
+	}
+}

--- a/pkg/kor/volumeattachments_test.go
+++ b/pkg/kor/volumeattachments_test.go
@@ -132,7 +132,7 @@ func TestFilterOwnerReferencedVolumeAttachments(t *testing.T) {
 			Name: "test-pod",
 		},
 	}
-	
+
 	// Standalone VolumeAttachment (with invalid PV to make it unused)
 	standaloneVA := CreateTestVolumeAttachment("standalone-va", "csi-driver-1", "node-1", "invalid-pv")
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR addresses issue where unused resource reports were cluttered with resources that aren't truly orphaned:

- **ReplicaSets owned by Deployments/StatefulSets**: These are kept for rollback history up to `revisionHistoryLimit` and shouldn't be considered orphaned
- **Jobs created by CronJobs**: These are useful for checking logs of last successful/failed runs and are managed by their parent CronJob

**Added Features:**
- `--skip-deployment-replicasets` flag: Filters out ReplicaSets owned by Deployments or StatefulSets using owner reference checking
- `--skip-cronjob-jobs` flag: Filters out Jobs created by CronJobs using owner reference checking

**Usage Examples:**
```bash
# Skip deployment-owned replicasets
kor replicaset --skip-deployment-replicasets

# Skip cronjob-created jobs  
kor job --skip-cronjob-jobs

# Use both flags together
kor all --skip-deployment-replicasets --skip-cronjob-jobs

# Works with multi-resource queries
kor "replicaset,job,configmap" --skip-deployment-replicasets
```

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [x] This PR includes tests for new/existing code
- [x] This PR adds docs

## GitHub Issue

Closes [#341](https://github.com/yonahd/kor/issues/341)

## Notes for your reviewers

- **Owner Reference Logic**: Used Kubernetes standard owner reference checking to identify parent-child relationships
- **Backward Compatibility**: All existing functionality remains unchanged, new flags are optional
- **Test Coverage**: Added comprehensive tests for both filtering scenarios including edge cases
- **Multi-resource Support**: Both flags work seamlessly with existing multi-resource queries and output formats
- **Real Cluster Testing**: Verified functionality against actual EKS cluster with deployment history and cronjob schedules