### PR TITLE
fix: correct indentation in deployment template for nodeSelector

### DIFF
--- a/charts/kor/templates/deployment.yaml
+++ b/charts/kor/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
             {{ toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.prometheusExporter.deployment.image.repository }}:{{ .Values.prometheusExporter.deployment.image.tag }}"
+          imagePullPolicy: {{ .Values.prometheusExporter.deployment.imagePullPolicy }}
+          terminationMessagePath: "/dev/termination-log"
           command:
             {{- toYaml .Values.prometheusExporter.command | nindent 12 }}
           args:
@@ -61,8 +63,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-          terminationMessagePath: "/dev/termination-log"
-          imagePullPolicy: {{ .Values.prometheusExporter.deployment.imagePullPolicy }}
       restartPolicy: {{ .Values.prometheusExporter.deployment.restartPolicy }}
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
The terminationMessagePath and imagePullPolicy were incorrectly placed outside the container spec, causing YAML parse errors when nodeSelector was defined. This fix moves these properties to their correct location within the container definition.

Fixes: YAML parse error on deployment.yaml line 50

## Description
Fixes a YAML parsing error in the deployment template when `nodeSelector` is configured.

## Problem
When setting `prometheusExporter.deployment.nodeSelector`, the Helm chart fails with:

## Root Cause
The `terminationMessagePath` and `imagePullPolicy` properties were placed at the wrong indentation level, appearing after the `nodeSelector`/`affinity`/`tolerations` blocks instead of inside the container spec.

## Solution
Moved `terminationMessagePath` and `imagePullPolicy` to their correct location within the container definition.

## Testing
- [x] Tested with `helm template`
- [x] Tested with `helm lint`
- [x] Successfully deployed to GKE cluster with nodeSelector configured

## Chart Version
Affects version: 0.2.4