### PR TITLE
Disable resource grouping flag for `exporter` subcommand

### DIFF
--- a/cmd/kor/all.go
+++ b/cmd/kor/all.go
@@ -29,6 +29,7 @@ var allCmd = &cobra.Command{
 }
 
 func init() {
-	allCmd.Flags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
+	addGroupByFlag(allCmd)
+	addNamespacedFlag(allCmd)
 	rootCmd.AddCommand(allCmd)
 }

--- a/cmd/kor/clusterrolebindings.go
+++ b/cmd/kor/clusterrolebindings.go
@@ -27,5 +27,6 @@ var clusterRoleBindingCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(clusterRoleBindingCmd)
 	rootCmd.AddCommand(clusterRoleBindingCmd)
 }

--- a/cmd/kor/clusterroles.go
+++ b/cmd/kor/clusterroles.go
@@ -27,5 +27,6 @@ var clusterRoleCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(clusterRoleCmd)
 	rootCmd.AddCommand(clusterRoleCmd)
 }

--- a/cmd/kor/configmaps.go
+++ b/cmd/kor/configmaps.go
@@ -26,5 +26,6 @@ var configmapCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(configmapCmd)
 	rootCmd.AddCommand(configmapCmd)
 }

--- a/cmd/kor/crds.go
+++ b/cmd/kor/crds.go
@@ -28,5 +28,6 @@ var crdCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(crdCmd)
 	rootCmd.AddCommand(crdCmd)
 }

--- a/cmd/kor/daemonsets.go
+++ b/cmd/kor/daemonsets.go
@@ -27,5 +27,6 @@ var dsCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(dsCmd)
 	rootCmd.AddCommand(dsCmd)
 }

--- a/cmd/kor/deployments.go
+++ b/cmd/kor/deployments.go
@@ -26,5 +26,6 @@ var deployCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(deployCmd)
 	rootCmd.AddCommand(deployCmd)
 }

--- a/cmd/kor/exporter.go
+++ b/cmd/kor/exporter.go
@@ -23,7 +23,7 @@ var exporterCmd = &cobra.Command{
 }
 
 func init() {
-	exporterCmd.Flags().StringSliceVarP(&resourceList, "resources", "r", nil, "Comma-separated list of resources to monitor (e.g., deployment,service)")
-	exporterCmd.Flags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
+	addNamespacedFlag(exporterCmd)
+	addResourcesFlag(exporterCmd)
 	rootCmd.AddCommand(exporterCmd)
 }

--- a/cmd/kor/finalizers.go
+++ b/cmd/kor/finalizers.go
@@ -26,5 +26,6 @@ var finalizerCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(finalizerCmd)
 	rootCmd.AddCommand(finalizerCmd)
 }

--- a/cmd/kor/hpas.go
+++ b/cmd/kor/hpas.go
@@ -28,5 +28,6 @@ var hpaCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(hpaCmd)
 	rootCmd.AddCommand(hpaCmd)
 }

--- a/cmd/kor/ingresses.go
+++ b/cmd/kor/ingresses.go
@@ -27,5 +27,6 @@ var ingressCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(ingressCmd)
 	rootCmd.AddCommand(ingressCmd)
 }

--- a/cmd/kor/jobs.go
+++ b/cmd/kor/jobs.go
@@ -27,5 +27,6 @@ var jobCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(jobCmd)
 	rootCmd.AddCommand(jobCmd)
 }

--- a/cmd/kor/networkpolicies.go
+++ b/cmd/kor/networkpolicies.go
@@ -26,5 +26,6 @@ var netpolCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(netpolCmd)
 	rootCmd.AddCommand(netpolCmd)
 }

--- a/cmd/kor/pdbs.go
+++ b/cmd/kor/pdbs.go
@@ -27,5 +27,6 @@ var pdbCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(pdbCmd)
 	rootCmd.AddCommand(pdbCmd)
 }

--- a/cmd/kor/pods.go
+++ b/cmd/kor/pods.go
@@ -27,5 +27,6 @@ var podCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(podCmd)
 	rootCmd.AddCommand(podCmd)
 }

--- a/cmd/kor/priorityclasses.go
+++ b/cmd/kor/priorityclasses.go
@@ -28,5 +28,6 @@ var priorityClassCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(priorityClassCmd)
 	rootCmd.AddCommand(priorityClassCmd)
 }

--- a/cmd/kor/pv.go
+++ b/cmd/kor/pv.go
@@ -28,5 +28,6 @@ var pvCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(pvCmd)
 	rootCmd.AddCommand(pvCmd)
 }

--- a/cmd/kor/pvc.go
+++ b/cmd/kor/pvc.go
@@ -28,5 +28,6 @@ var pvcCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(pvcCmd)
 	rootCmd.AddCommand(pvcCmd)
 }

--- a/cmd/kor/replicasets.go
+++ b/cmd/kor/replicasets.go
@@ -27,5 +27,6 @@ var replicaSetCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(replicaSetCmd)
 	rootCmd.AddCommand(replicaSetCmd)
 }

--- a/cmd/kor/rolebindings.go
+++ b/cmd/kor/rolebindings.go
@@ -27,5 +27,6 @@ var roleBindingCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(roleBindingCmd)
 	rootCmd.AddCommand(roleBindingCmd)
 }

--- a/cmd/kor/roles.go
+++ b/cmd/kor/roles.go
@@ -27,5 +27,6 @@ var roleCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(roleCmd)
 	rootCmd.AddCommand(roleCmd)
 }

--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -64,6 +64,7 @@ func init() {
 	initFlags()
 	initViper()
 	addFilterOptionsFlag(rootCmd, filterOptions)
+	addGroupByFlag(rootCmd)
 }
 
 func initKindsList() {
@@ -83,7 +84,6 @@ func initFlags() {
 	rootCmd.PersistentFlags().BoolVar(&opts.DeleteFlag, "delete", false, "Delete unused resources")
 	rootCmd.PersistentFlags().BoolVar(&opts.NoInteractive, "no-interactive", false, "Do not prompt for confirmation when deleting resources. Be careful when using this flag!")
 	rootCmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output (print empty namespaces)")
-	rootCmd.PersistentFlags().StringVar(&opts.GroupBy, "group-by", "namespace", "Group output by (namespace, resource)")
 	rootCmd.PersistentFlags().BoolVar(&opts.ShowReason, "show-reason", false, "Print reason resource is considered unused")
 }
 
@@ -123,6 +123,18 @@ func Execute() {
 		fmt.Fprintf(os.Stderr, "Error while executing your CLI '%s'", err)
 		os.Exit(1)
 	}
+}
+
+func addGroupByFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&opts.GroupBy, "group-by", "namespace", "Group output by (namespace, resource)")
+}
+
+func addNamespacedFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&opts.Namespaced, "namespaced", true, "If false, non-namespaced resources will be returned, otherwise returning namespaced resources by default. If not used, both are returned")
+}
+
+func addResourcesFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVarP(&resourceList, "resources", "r", nil, "Comma-separated list of resources to monitor (e.g., deployment,service)")
 }
 
 func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {

--- a/cmd/kor/secrets.go
+++ b/cmd/kor/secrets.go
@@ -27,5 +27,6 @@ var secretCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(secretCmd)
 	rootCmd.AddCommand(secretCmd)
 }

--- a/cmd/kor/serviceaccounts.go
+++ b/cmd/kor/serviceaccounts.go
@@ -27,5 +27,6 @@ var serviceAccountCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(serviceAccountCmd)
 	rootCmd.AddCommand(serviceAccountCmd)
 }

--- a/cmd/kor/services.go
+++ b/cmd/kor/services.go
@@ -27,5 +27,6 @@ var serviceCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(serviceCmd)
 	rootCmd.AddCommand(serviceCmd)
 }

--- a/cmd/kor/statefulsets.go
+++ b/cmd/kor/statefulsets.go
@@ -27,5 +27,6 @@ var stsCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(stsCmd)
 	rootCmd.AddCommand(stsCmd)
 }

--- a/cmd/kor/storageclasses.go
+++ b/cmd/kor/storageclasses.go
@@ -28,5 +28,6 @@ var scCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(scCmd)
 	rootCmd.AddCommand(scCmd)
 }

--- a/cmd/kor/volumeattachments.go
+++ b/cmd/kor/volumeattachments.go
@@ -27,5 +27,6 @@ var volumeAttachmentCmd = &cobra.Command{
 }
 
 func init() {
+	addGroupByFlag(volumeAttachmentCmd)
 	rootCmd.AddCommand(volumeAttachmentCmd)
 }


### PR DESCRIPTION
## What this PR does / why we need it?

Makes changes to flag definitions withing both the root command and all subcommands in such a way that everything _except_ `exporter` will be able to specify `--group-by`. 

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [X] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs

## GitHub Issue

Closes #555
