### PR TITLE
feat: add skip namespace validation option for RBAC filters

### DIFF
--- a/cmd/kor/root.go
+++ b/cmd/kor/root.go
@@ -133,6 +133,7 @@ func addFilterOptionsFlag(cmd *cobra.Command, opts *filters.Options) {
 	cmd.PersistentFlags().StringSliceVarP(&opts.ExcludeNamespaces, "exclude-namespaces", "e", opts.ExcludeNamespaces, "Namespaces to be excluded, split by commas. Example: --exclude-namespaces ns1,ns2,ns3. If --include-namespaces is set, --exclude-namespaces will be ignored")
 	cmd.PersistentFlags().StringSliceVarP(&opts.IncludeNamespaces, "include-namespaces", "n", opts.IncludeNamespaces, "Namespaces to run on, split by commas. Example: --include-namespaces ns1,ns2,ns3. If set, non-namespaced resources will be ignored")
 	cmd.PersistentFlags().BoolVar(&opts.IgnoreOwnerReferences, "ignore-owner-references", false, "Skip resources that have ownerReferences set (for all resource types)")
+	cmd.PersistentFlags().BoolVar(&opts.SkipNamespaceValidation, "skip-namespace-validation", false, "Skip namespace existence validation (requires --include-namespaces). Use in permission-limited clusters with only Role/RoleBinding")
 }
 
 // shouldSkipKubeInitialization determines if a command should skip kubeconfig initialization.


### PR DESCRIPTION
## What this PR does / why we need it?

Split from https://github.com/yonahd/kor/pull/563/.  

Currently, there's a hard-coded validation check in the code to verify that the supplied namespaces exist. However, clusters with limited permissions may not have the permission to list all namespaces. I added a flag to optionally disable this check for such cases.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [x] This PR adds new code
- [ ] This PR includes tests for new/existing code
- [ ] This PR adds docs

## GitHub Issue

Not applicable (I think). Feel free to create one retroactively.