### PR TITLE
fix(clusterroles): replace strconv.ParseBool with true assignment

### DIFF
--- a/pkg/kor/clusterroles.go
+++ b/pkg/kor/clusterroles.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +71,7 @@ func retrieveUsedClusterRoles(clientset kubernetes.Interface, filterOpts *filter
 	for _, clusterRole := range clusterRoles.Items {
 		clusterRolesMap[clusterRole.Name] = clusterRole
 	}
-	// Create a list wich holds all aggregated labels
+	// Create a list which holds all aggregated labels
 	aggregatedLabels := make([]string, 0)
 
 	for clusterRole := range usedClusterRoles {
@@ -89,10 +88,7 @@ func retrieveUsedClusterRoles(clientset kubernetes.Interface, filterOpts *filter
 		for _, clusterRole := range clusterRoles.Items {
 			for label, value := range clusterRole.Labels {
 				if slices.Contains(aggregatedLabels, label+": "+value) {
-					usedClusterRoles[clusterRole.Name], err = strconv.ParseBool(value)
-					if err != nil {
-						return nil, fmt.Errorf("couldn't convert string to bool %v", err)
-					}
+					usedClusterRoles[clusterRole.Name] = true
 					if clusterRole.AggregationRule == nil {
 						continue
 					}

--- a/pkg/kor/clusterroles_test.go
+++ b/pkg/kor/clusterroles_test.go
@@ -275,6 +275,51 @@ func TestGetUnusedClusterRolesStructuredWithOwnerReferences(t *testing.T) {
 	}
 }
 
+func TestRetrieveUsedClusterRolesWithNonBooleanLabels(t *testing.T) {
+	// Regression test for: strconv.ParseBool called on arbitrary label value
+	// A parent ClusterRole with an AggregationRule whose matchLabels selector uses
+	// a non-boolean value (e.g. "app: kyverno") must not cause an error.
+	clientset := fake.NewClientset()
+
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: testNamespace},
+	}, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating namespace %s: %v", testNamespace, err)
+	}
+
+	nonBoolSelector := map[string]string{"app": "kyverno"}
+	parentRole := CreateTestClusterRole("parent-clusterRole", AppLabels, v1.LabelSelector{MatchLabels: nonBoolSelector})
+	_, err = clientset.RbacV1().ClusterRoles().Create(context.TODO(), parentRole, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating parent ClusterRole: %v", err)
+	}
+
+	childRole := CreateTestClusterRole("child-clusterRole", nonBoolSelector)
+	_, err = clientset.RbacV1().ClusterRoles().Create(context.TODO(), childRole, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating child ClusterRole: %v", err)
+	}
+
+	parentRoleRef := CreateTestRoleRefForClusterRole("parent-clusterRole")
+	crb := CreateTestClusterRoleBindingRoleRef(testNamespace, "test-crb-nbl", "test-sa", parentRoleRef)
+	_, err = clientset.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating ClusterRoleBinding: %v", err)
+	}
+
+	usedClusterRoles, err := retrieveUsedClusterRoles(clientset, &filters.Options{})
+	if err != nil {
+		t.Errorf("Expected no error with non-boolean label values, got %v", err)
+	}
+
+	sort.Strings(usedClusterRoles)
+	expectedRoles := []string{"child-clusterRole", "parent-clusterRole"}
+	if !reflect.DeepEqual(usedClusterRoles, expectedRoles) {
+		t.Errorf("Expected roles %v, got %v", expectedRoles, usedClusterRoles)
+	}
+}
+
 func init() {
 	scheme.Scheme = runtime.NewScheme()
 	_ = appsv1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository! -->

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it?

`retrieveUsedClusterRoles` was calling `strconv.ParseBool` on Kubernetes label **values** to populate a `map[string]bool` that tracks which ClusterRole names are in use. Label values are arbitrary strings (e.g. `"kyverno"`, `"admission-controller"`), so `ParseBool` fails on any non-boolean value, causing the function to return an error early and leaving aggregated ClusterRoles untracked — producing false-positive orphaned ClusterRole reports.

The fix replaces the `strconv.ParseBool` call with a plain `true` assignment (the map's semantic is always "this role is used") and removes the now-unused `strconv` import. A regression test is added that exercises the exact scenario: a parent ClusterRole with an AggregationRule using a non-boolean `matchLabels` selector (`app: kyverno`) and a child ClusterRole that carries that label. The test asserts no error is returned and both roles appear as used.

## PR Checklist

- [ ] This PR adds K8s exceptions (false positives)
- [ ] This PR adds new code
- [x] This PR includes tests for new/existing code
- [ ] This PR adds docs
<!-- - [ ] This PR does something else -->

## GitHub Issue

Closes [XX-XX]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

The `err` variable previously used only for `strconv.ParseBool` is now unused in the aggregation loop; no other error paths were removed. The `strconv` import was the only use of that package in the file and has been removed. All existing tests continue to pass.
